### PR TITLE
Optimus dark

### DIFF
--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -360,12 +360,6 @@ export default function ActivityPage() {
                             <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
-                            <Link
-                                href="/foro"
-                                className="text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 font-medium text-sm transition-colors"
-                            >
-                                Communities
-                            </Link>
                             <ThemeToggle />
                             {isConnected ? (
                                 <WalletConnect />
@@ -432,7 +426,10 @@ export default function ActivityPage() {
                                 {/* Community Header */}
                                 <div className="px-6 py-5 border-b border-slate-100 dark:border-slate-700 bg-gradient-to-r from-slate-50/80 dark:from-slate-700/50 to-transparent">
                                     <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-4">
+                                        <Link 
+                                            href={`/foro?community=${community.id}`}
+                                            className="flex items-center gap-4 hover:opacity-80 transition-opacity"
+                                        >
                                             {community.photo ? (
                                                 <img 
                                                     src={`${BACKUP_GATEWAY}${community.photo}`}
@@ -457,7 +454,7 @@ export default function ActivityPage() {
                                                     </span>
                                                 </div>
                                             </div>
-                                        </div>
+                                        </Link>
                                         {isConnected ? (
                                             community.isMember ? (
                                                 <Link

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -9,6 +9,7 @@ import axios from 'axios';
 import { forumAddress, forumABI } from "@/contracts/DecentralizedForum_V3.3";
 import { Clock, MessageSquare, Heart, Users, ArrowRight, Sparkles, TrendingUp, Wallet } from "lucide-react";
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 // Public RPC for Arbitrum One - allows reading without wallet connection
 const ARBITRUM_RPC = "https://arb1.arbitrum.io/rpc";
@@ -48,6 +49,7 @@ interface Community {
 
 export default function ActivityPage() {
     const { isConnected, provider, address, connect } = useWalletContext();
+    const router = useRouter();
     const [communities, setCommunities] = useState<Community[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [joiningCommunityId, setJoiningCommunityId] = useState<string | null>(null);
@@ -269,6 +271,22 @@ export default function ActivityPage() {
         }
     };
 
+    // Handle navigation to forum ensuring wallet connection first
+    const handleGoToForo = async () => {
+        if (!isConnected) {
+            setIsConnecting(true);
+            try {
+                await connect();
+            } catch (error) {
+                console.error("Error connecting before navigating to foro:", error);
+                setIsConnecting(false);
+                return;
+            }
+            setIsConnecting(false);
+        }
+        router.push('/foro');
+    };
+
     // Join a community
     const handleJoinCommunity = async (communityId: string) => {
         if (!provider || !isConnected) {
@@ -341,12 +359,13 @@ export default function ActivityPage() {
                             <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
-                            <Link 
-                                href="/foro"
+                            <button
+                                type="button"
+                                onClick={handleGoToForo}
                                 className="text-slate-600 hover:text-slate-900 font-medium text-sm transition-colors"
                             >
                                 Communities
-                            </Link>
+                            </button>
                             {isConnected ? (
                                 <WalletConnect />
                             ) : (
@@ -391,13 +410,14 @@ export default function ActivityPage() {
                         </div>
                         <h3 className="text-xl font-semibold text-slate-900 mb-2">No activity yet</h3>
                         <p className="text-slate-500 mb-6">Be the first to create a post in a community!</p>
-                        <Link 
-                            href="/foro"
+                        <button
+                            type="button"
+                            onClick={handleGoToForo}
                             className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-slate-900 to-slate-800 text-white font-medium text-sm shadow-lg hover:shadow-xl transition-all"
                         >
                             Browse Communities
                             <ArrowRight className="w-4 h-4" />
-                        </Link>
+                        </button>
                     </div>
                 )}
 

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -10,6 +10,7 @@ import { forumAddress, forumABI } from "@/contracts/DecentralizedForum_V3.3";
 import { Clock, MessageSquare, Heart, Users, ArrowRight, Sparkles, TrendingUp, Wallet } from "lucide-react";
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 // Public RPC for Arbitrum One - allows reading without wallet connection
 const ARBITRUM_RPC = "https://arb1.arbitrum.io/rpc";
@@ -347,31 +348,32 @@ export default function ActivityPage() {
     };
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff]">
+        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 transition-colors duration-300">
             <div className="max-w-6xl mx-auto px-6 py-8">
                 {/* Header with Connect button on the right */}
                 <header className="mb-10">
                     <div className="flex justify-between items-center">
                         <Link href="/" className="flex items-center gap-3">
-                            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-sky-200">
+                            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-sky-200 dark:shadow-sky-900/50">
                                 <Sparkles className="w-5 h-5 text-white" />
                             </div>
-                            <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
+                            <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
                             <Link
                                 href="/foro"
-                                className="text-slate-600 hover:text-slate-900 font-medium text-sm transition-colors"
+                                className="text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 font-medium text-sm transition-colors"
                             >
                                 Communities
                             </Link>
+                            <ThemeToggle />
                             {isConnected ? (
                                 <WalletConnect />
                             ) : (
                                 <button
                                     onClick={() => handleConnect()}
                                     disabled={isConnecting}
-                                    className="inline-flex items-center justify-center rounded-full bg-sky-100 text-sky-800 border border-sky-200 hover:bg-sky-200 transition-colors text-xs font-medium px-5 py-2 h-auto shadow-sm disabled:opacity-70"
+                                    className="inline-flex items-center justify-center rounded-full bg-sky-100 dark:bg-sky-900/50 text-sky-800 dark:text-sky-300 border border-sky-200 dark:border-sky-800 hover:bg-sky-200 dark:hover:bg-sky-800/50 transition-colors text-xs font-medium px-5 py-2 h-auto shadow-sm disabled:opacity-70"
                                 >
                                     {isConnecting ? "Connecting..." : "Connect"}
                                 </button>
@@ -383,32 +385,32 @@ export default function ActivityPage() {
                 {/* Page Title */}
                 <div className="mb-8">
                     <div className="flex items-center gap-3 mb-2">
-                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-violet-100 to-violet-50 flex items-center justify-center">
-                            <TrendingUp className="w-5 h-5 text-violet-600" />
+                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-violet-100 to-violet-50 dark:from-violet-900/50 dark:to-violet-800/30 flex items-center justify-center">
+                            <TrendingUp className="w-5 h-5 text-violet-600 dark:text-violet-400" />
                         </div>
-                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900">Recent Activity</h2>
+                        <h2 className="text-2xl md:text-3xl font-bold text-slate-900 dark:text-slate-100">Recent Activity</h2>
                     </div>
-                    <p className="text-slate-500 ml-13">Latest posts from all communities</p>
+                    <p className="text-slate-500 dark:text-slate-400 ml-13">Latest posts from all communities</p>
                 </div>
 
                 {/* Loading State */}
                 {isLoading && (
                     <div className="flex items-center justify-center py-20">
                         <div className="text-center">
-                            <div className="w-12 h-12 rounded-full border-4 border-sky-200 border-t-sky-500 animate-spin mx-auto mb-4"></div>
-                            <p className="text-slate-500">Loading activity...</p>
+                            <div className="w-12 h-12 rounded-full border-4 border-sky-200 dark:border-sky-800 border-t-sky-500 animate-spin mx-auto mb-4"></div>
+                            <p className="text-slate-500 dark:text-slate-400">Loading activity...</p>
                         </div>
                     </div>
                 )}
 
                 {/* Communities with Posts */}
                 {!isLoading && communities.length === 0 && (
-                    <div className="bg-white/80 backdrop-blur-xl rounded-2xl shadow-xl border border-white/60 p-12 text-center">
-                        <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center mx-auto mb-4">
+                    <div className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-2xl shadow-xl border border-white/60 dark:border-slate-700 p-12 text-center">
+                        <div className="w-16 h-16 rounded-2xl bg-slate-100 dark:bg-slate-700 flex items-center justify-center mx-auto mb-4">
                             <MessageSquare className="w-8 h-8 text-slate-400" />
                         </div>
-                        <h3 className="text-xl font-semibold text-slate-900 mb-2">No activity yet</h3>
-                        <p className="text-slate-500 mb-6">Be the first to create a post in a community!</p>
+                        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-2">No activity yet</h3>
+                        <p className="text-slate-500 dark:text-slate-400 mb-6">Be the first to create a post in a community!</p>
                         <button
                             type="button"
                             onClick={handleGoToForo}
@@ -425,10 +427,10 @@ export default function ActivityPage() {
                         {communities.map((community) => (
                             <div 
                                 key={community.id}
-                                className="bg-white/80 backdrop-blur-xl rounded-2xl shadow-xl shadow-slate-200/40 border border-white/60 overflow-hidden"
+                                className="bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-2xl shadow-xl shadow-slate-200/40 dark:shadow-slate-900/40 border border-white/60 dark:border-slate-700 overflow-hidden"
                             >
                                 {/* Community Header */}
-                                <div className="px-6 py-5 border-b border-slate-100 bg-gradient-to-r from-slate-50/80 to-transparent">
+                                <div className="px-6 py-5 border-b border-slate-100 dark:border-slate-700 bg-gradient-to-r from-slate-50/80 dark:from-slate-700/50 to-transparent">
                                     <div className="flex items-center justify-between">
                                         <div className="flex items-center gap-4">
                                             {community.photo ? (
@@ -438,13 +440,13 @@ export default function ActivityPage() {
                                                     className="w-12 h-12 rounded-xl object-cover shadow-md"
                                                 />
                                             ) : (
-                                                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-sky-100 to-indigo-100 flex items-center justify-center shadow-md">
-                                                    <Users className="w-6 h-6 text-sky-600" />
+                                                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-sky-100 to-indigo-100 dark:from-sky-900/50 dark:to-indigo-900/50 flex items-center justify-center shadow-md">
+                                                    <Users className="w-6 h-6 text-sky-600 dark:text-sky-400" />
                                                 </div>
                                             )}
                                             <div>
-                                                <h3 className="font-semibold text-slate-900 text-lg">{community.name}</h3>
-                                                <div className="flex items-center gap-4 text-sm text-slate-500">
+                                                <h3 className="font-semibold text-slate-900 dark:text-slate-100 text-lg">{community.name}</h3>
+                                                <div className="flex items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
                                                     <span className="flex items-center gap-1">
                                                         <Users className="w-3.5 h-3.5" />
                                                         {community.memberCount} members
@@ -491,11 +493,11 @@ export default function ActivityPage() {
                                 </div>
 
                                 {/* Posts */}
-                                <div className="divide-y divide-slate-100">
+                                <div className="divide-y divide-slate-100 dark:divide-slate-700">
                                     {community.posts.map((post) => (
                                         <div 
                                             key={post.id}
-                                            className="px-6 py-5 hover:bg-slate-50/50 transition-colors"
+                                            className="px-6 py-5 hover:bg-slate-50/50 dark:hover:bg-slate-700/50 transition-colors"
                                         >
                                             <div className="flex gap-4">
                                                 {/* Post Image (if exists) */}
@@ -512,10 +514,10 @@ export default function ActivityPage() {
                                                 {/* Post Content */}
                                                 <div className="flex-1 min-w-0">
                                                     <div className="flex items-start justify-between gap-4 mb-2">
-                                                        <p className="text-sm text-slate-600 line-clamp-2 flex-1">
+                                                        <p className="text-sm text-slate-600 dark:text-slate-300 line-clamp-2 flex-1">
                                                             {stripHtmlAndTruncate(post.content)}
                                                         </p>
-                                                        <span className="flex-shrink-0 text-xs text-slate-400 flex items-center gap-1">
+                                                        <span className="flex-shrink-0 text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
                                                             <Clock className="w-3 h-3" />
                                                             {formatRelativeTime(post.timestamp)}
                                                         </span>
@@ -529,12 +531,12 @@ export default function ActivityPage() {
                                                                 showNickname={true}
                                                             />
                                                             {post.topic && (
-                                                                <span className="text-xs px-2 py-0.5 rounded-full bg-slate-100 text-slate-600">
+                                                                <span className="text-xs px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
                                                                     {post.topic}
                                                                 </span>
                                                             )}
                                                         </div>
-                                                        <div className="flex items-center gap-4 text-xs text-slate-400">
+                                                        <div className="flex items-center gap-4 text-xs text-slate-400 dark:text-slate-500">
                                                             <span className="flex items-center gap-1">
                                                                 <Heart className="w-3.5 h-3.5" />
                                                                 {post.likeCount}

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -359,6 +359,12 @@ export default function ActivityPage() {
                             <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
+                            <Link
+                                href="/foro"
+                                className="text-slate-600 hover:text-slate-900 font-medium text-sm transition-colors"
+                            >
+                                Communities
+                            </Link>
                             {isConnected ? (
                                 <WalletConnect />
                             ) : (
@@ -424,10 +430,7 @@ export default function ActivityPage() {
                                 {/* Community Header */}
                                 <div className="px-6 py-5 border-b border-slate-100 bg-gradient-to-r from-slate-50/80 to-transparent">
                                     <div className="flex items-center justify-between">
-                                        <Link 
-                                            href={`/foro?community=${community.id}`}
-                                            className="flex items-center gap-4"
-                                        >
+                                        <div className="flex items-center gap-4">
                                             {community.photo ? (
                                                 <img 
                                                     src={`${BACKUP_GATEWAY}${community.photo}`}
@@ -452,7 +455,7 @@ export default function ActivityPage() {
                                                     </span>
                                                 </div>
                                             </div>
-                                        </Link>
+                                        </div>
                                         {isConnected ? (
                                             community.isMember ? (
                                                 <Link

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -424,7 +424,10 @@ export default function ActivityPage() {
                                 {/* Community Header */}
                                 <div className="px-6 py-5 border-b border-slate-100 bg-gradient-to-r from-slate-50/80 to-transparent">
                                     <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-4">
+                                        <Link 
+                                            href={`/foro?community=${community.id}`}
+                                            className="flex items-center gap-4"
+                                        >
                                             {community.photo ? (
                                                 <img 
                                                     src={`${BACKUP_GATEWAY}${community.photo}`}
@@ -449,7 +452,7 @@ export default function ActivityPage() {
                                                     </span>
                                                 </div>
                                             </div>
-                                        </div>
+                                        </Link>
                                         {isConnected ? (
                                             community.isMember ? (
                                                 <Link

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -359,13 +359,12 @@ export default function ActivityPage() {
                             <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
-                            <button
-                                type="button"
-                                onClick={handleGoToForo}
+                            <Link
+                                href="/foro"
                                 className="text-slate-600 hover:text-slate-900 font-medium text-sm transition-colors"
                             >
                                 Communities
-                            </button>
+                            </Link>
                             {isConnected ? (
                                 <WalletConnect />
                             ) : (

--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -359,12 +359,6 @@ export default function ActivityPage() {
                             <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
                         </Link>
                         <div className="flex items-center gap-4">
-                            <Link
-                                href="/foro"
-                                className="text-slate-600 hover:text-slate-900 font-medium text-sm transition-colors"
-                            >
-                                Communities
-                            </Link>
                             {isConnected ? (
                                 <WalletConnect />
                             ) : (

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Shield, ArrowLeft, Users, Home, EyeOff, Construction } from "lucide-react";
 import Link from "next/link";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function AdminPage() {
   const router = useRouter();
@@ -27,10 +28,10 @@ export default function AdminPage() {
   // Show loading while checking connection
   if (!isConnected) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center transition-colors duration-300">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-slate-900 mx-auto mb-4"></div>
-          <p className="text-slate-600">Verificando conexión...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-slate-900 dark:border-slate-100 mx-auto mb-4"></div>
+          <p className="text-slate-600 dark:text-slate-400">Verificando conexión...</p>
         </div>
       </div>
     );
@@ -39,7 +40,7 @@ export default function AdminPage() {
   // Show access denied if not admin
   if (!isAdmin) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center p-4 transition-colors duration-300">
         <Card className="max-w-md w-full border-red-200 bg-red-50">
           <CardHeader>
             <CardTitle className="text-red-800 flex items-center gap-2">
@@ -77,42 +78,43 @@ export default function AdminPage() {
 
   // Admin dashboard
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800 transition-colors duration-300">
       {/* Header */}
-      <header className="bg-white border-b border-slate-200 sticky top-0 z-50 shadow-sm">
+      <header className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 sticky top-0 z-50 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
               <div className="flex items-center gap-3">
-                <div className="bg-slate-900 text-white p-2 rounded-lg">
+                <div className="bg-slate-900 dark:bg-slate-700 text-white p-2 rounded-lg">
                   <Shield className="w-6 h-6" />
                 </div>
                 <div>
                   <div className="flex items-center gap-2">
-                    <h1 className="text-2xl font-bold text-slate-900">
+                    <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
                       Panel de Administración
                     </h1>
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-100 text-amber-700 text-xs font-medium rounded-full border border-amber-200">
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-400 text-xs font-medium rounded-full border border-amber-200 dark:border-amber-800">
                       <Construction className="w-3 h-3" />
                       En construcción
                     </span>
                   </div>
-                  <p className="text-sm text-slate-500">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
                     NodeSpeak - Centro de Moderación
                   </p>
                 </div>
               </div>
             </div>
             <div className="flex items-center gap-3">
+              <ThemeToggle />
               <Link href="/foro">
                 <Button variant="outline" size="sm" className="gap-2">
                   <ArrowLeft className="w-4 h-4" />
                   Volver al Foro
                 </Button>
               </Link>
-              <div className="bg-slate-100 px-4 py-2 rounded-lg">
-                <p className="text-xs text-slate-500 mb-1">Administrador conectado</p>
-                <p className="text-sm font-medium text-slate-900">
+              <div className="bg-slate-100 dark:bg-slate-700 px-4 py-2 rounded-lg">
+                <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Administrador conectado</p>
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
                   {ensName || `${address?.slice(0, 6)}...${address?.slice(-4)}`}
                 </p>
               </div>
@@ -125,31 +127,31 @@ export default function AdminPage() {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-          <Card>
+          <Card className="dark:bg-slate-800 dark:border-slate-700">
             <CardHeader className="pb-3">
-              <CardDescription>Usuarios Ocultados</CardDescription>
-              <CardTitle className="text-3xl flex items-center gap-2">
-                <Users className="w-6 h-6 text-slate-500" />
+              <CardDescription className="dark:text-slate-400">Usuarios Ocultados</CardDescription>
+              <CardTitle className="text-3xl flex items-center gap-2 dark:text-slate-100">
+                <Users className="w-6 h-6 text-slate-500 dark:text-slate-400" />
                 {hiddenUsers.length}
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-slate-400">
                 Usuarios actualmente ocultos en la plataforma
               </p>
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="dark:bg-slate-800 dark:border-slate-700">
             <CardHeader className="pb-3">
-              <CardDescription>Comunidades Ocultadas</CardDescription>
-              <CardTitle className="text-3xl flex items-center gap-2">
-                <Home className="w-6 h-6 text-slate-500" />
+              <CardDescription className="dark:text-slate-400">Comunidades Ocultadas</CardDescription>
+              <CardTitle className="text-3xl flex items-center gap-2 dark:text-slate-100">
+                <Home className="w-6 h-6 text-slate-500 dark:text-slate-400" />
                 {hiddenCommunities.length}
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-slate-600">
+              <p className="text-sm text-slate-600 dark:text-slate-400">
                 Comunidades actualmente ocultas en la plataforma
               </p>
             </CardContent>
@@ -158,17 +160,17 @@ export default function AdminPage() {
 
         {/* Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="bg-white border border-slate-200 p-1">
+          <TabsList className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-1">
             <TabsTrigger
               value="hidden-users"
-              className="gap-2 data-[state=active]:bg-slate-900 data-[state=active]:text-white"
+              className="gap-2 data-[state=active]:bg-slate-900 dark:data-[state=active]:bg-slate-600 data-[state=active]:text-white dark:text-slate-300"
             >
               <Users className="w-4 h-4" />
               Usuarios Ocultados
             </TabsTrigger>
             <TabsTrigger
               value="my-communities"
-              className="gap-2 data-[state=active]:bg-slate-900 data-[state=active]:text-white"
+              className="gap-2 data-[state=active]:bg-slate-900 dark:data-[state=active]:bg-slate-600 data-[state=active]:text-white dark:text-slate-300"
             >
               <Home className="w-4 h-4" />
               Mis Comunidades
@@ -185,15 +187,15 @@ export default function AdminPage() {
         </Tabs>
 
         {/* Info Card */}
-        <Card className="mt-8 bg-slate-50">
+        <Card className="mt-8 bg-slate-50 dark:bg-slate-800/50 dark:border-slate-700">
           <CardHeader>
-            <CardTitle className="text-lg flex items-center gap-2">
+            <CardTitle className="text-lg flex items-center gap-2 dark:text-slate-100">
               <EyeOff className="w-5 h-5" />
               Sobre la Ocultación de Contenido
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-sm text-slate-600 space-y-4">
+            <div className="text-sm text-slate-600 dark:text-slate-400 space-y-4">
               <p>
                 Al ocultar un usuario o comunidad, este contenido dejará de ser visible para los usuarios
                 de la plataforma, pero los datos seguirán existiendo en la blockchain.

--- a/app/foro/page.tsx
+++ b/app/foro/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { WalletConnect } from '@/components/WalletConnect';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { AdminFloatingButton } from '@/components/admin/AdminFloatingButton';
 import { useState, useEffect, useMemo } from "react";
 import { useSearchParams } from 'next/navigation';
@@ -653,14 +654,15 @@ const handleCreateCommunity = async (
     }, [searchParams, communities]);
 
     return (
-        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff]">
+        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 transition-colors duration-300">
             <div className="max-w-7xl mx-auto px-6 py-8">
                 <header className="mb-10">
                     <div className="flex justify-between items-center">
                         <a href="/" className="block">
-                            <h1 className="text-2xl font-semibold text-slate-900 hover:text-indigo-600 transition-colors">Node Speak v3.3</h1>
+                            <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">Node Speak v3.3</h1>
                         </a>
-                        <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-3">
+                            <ThemeToggle />
                             <WalletConnect />
                         </div>
                     </div>
@@ -668,7 +670,7 @@ const handleCreateCommunity = async (
                         <div className="mt-4">
                             <button
                                 onClick={() => setShowCommunityList(true)}
-                                className="text-slate-500 text-sm px-4 py-2 rounded-lg hover:bg-white/50 transition-colors inline-flex items-center gap-2"
+                                className="text-slate-500 dark:text-slate-400 text-sm px-4 py-2 rounded-lg hover:bg-white/50 dark:hover:bg-slate-700/50 transition-colors inline-flex items-center gap-2"
                             >
                                 ← Communities
                             </button>
@@ -681,7 +683,7 @@ const handleCreateCommunity = async (
                         {/* Loading indicator */}
                         {isLoading && (
                             <div className="text-center p-6">
-                                <p className="text-slate-500 animate-pulse">Loading...</p>
+                                <p className="text-slate-500 dark:text-slate-400 animate-pulse">Loading...</p>
                             </div>
                         )}
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,23 @@
   --matrix-green: #10b981;
 }
 
+/* Dark theme colors */
+.dark {
+  --background: #0f172a;
+  --background-secondary: #1e293b;
+  --foreground: #f1f5f9;
+  --foreground-muted: #94a3b8;
+  --border: #334155;
+  --border-light: #1e293b;
+  --accent: #38bdf8;
+  --accent-light: #0c4a6e;
+  --success: #34d399;
+  --success-light: #064e3b;
+  --warning: #fbbf24;
+  --error: #f87171;
+  --error-light: #7f1d1d;
+}
+
 body {
   background: linear-gradient(135deg, #f5f7ff 0%, #fdfbff 50%, #e6f0ff 100%);
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -32,6 +49,12 @@ body {
   position: relative;
   overflow-x: hidden;
   min-height: 100vh;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.dark body,
+html.dark body {
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
 }
 
 /* Hide Matrix Rain Effect */
@@ -116,7 +139,7 @@ body {
   color: var(--foreground-muted);
 }
 
-/* Custom Scrollbar - Light theme */
+/* Custom Scrollbar */
 ::-webkit-scrollbar {
   width: 8px;
 }
@@ -132,6 +155,19 @@ body {
 }
 
 ::-webkit-scrollbar-thumb:hover {
+  background: var(--foreground-muted);
+}
+
+/* Dark mode scrollbar */
+.dark ::-webkit-scrollbar-track {
+  background: var(--border-light);
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: var(--border);
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
   background: var(--foreground-muted);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
                 <link rel="manifest" href="/site.webmanifest" />
             </head>
             <body>
-                <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+                <ThemeProvider attribute="class" defaultTheme="system" enableSystem={true} storageKey="nodespeak-theme">
                     <WalletProvider>
                         <AdminProvider>
                             <CommunitySettingsProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/toaster";
 import { WalletProvider } from '@/contexts/WalletContext';
 import { AdminProvider } from '@/contexts/AdminContext';
+import { CommunitySettingsProvider } from '@/contexts/CommunitySettingsContext';
 
 export const metadata: Metadata = {
     title: 'Node Speak',
@@ -38,8 +39,10 @@ export default function RootLayout({
                 <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
                     <WalletProvider>
                         <AdminProvider>
-                            {children}
-                            <Toaster />
+                            <CommunitySettingsProvider>
+                                {children}
+                                <Toaster />
+                            </CommunitySettingsProvider>
                         </AdminProvider>
                     </WalletProvider>
                 </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Github, X, Mail, Users, MessageSquare, Shield, Lock, Globe, Database, Sparkles } from "lucide-react";
 import { WalletConnect } from "@/components/WalletConnect";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { useWalletContext } from "@/contexts/WalletContext";
 import { useRouter } from 'next/navigation';
 import siteConfig from "@/config";
@@ -73,15 +74,15 @@ function Landing() {
     // Si está conectado, podemos mostrar un mensaje de carga mientras redirige
     if (isConnected) {
         return (
-            <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] flex items-center justify-center">
-                <div className="max-w-md w-full bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-100 px-8 py-10 text-center">
-                    <p className="text-sm font-semibold tracking-[0.2em] text-slate-500 uppercase mb-3">
+            <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 flex items-center justify-center transition-colors duration-300">
+                <div className="max-w-md w-full bg-white/80 dark:bg-slate-800/80 backdrop-blur-sm rounded-2xl shadow-xl border border-slate-100 dark:border-slate-700 px-8 py-10 text-center">
+                    <p className="text-sm font-semibold tracking-[0.2em] text-slate-500 dark:text-slate-400 uppercase mb-3">
                         Redirecting
                     </p>
-                    <p className="text-lg font-medium text-slate-800 mb-2">
+                    <p className="text-lg font-medium text-slate-800 dark:text-slate-100 mb-2">
                         Taking you to the forum…
                     </p>
-                    <p className="text-sm text-slate-500">
+                    <p className="text-sm text-slate-500 dark:text-slate-400">
                         <TypingEffect text="Loading your decentralized space" />
                     </p>
                 </div>
@@ -91,21 +92,22 @@ function Landing() {
 
     // Si no está conectado, muestra la landing principal con estilo claro
     return (
-        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] text-slate-900 relative overflow-hidden">
+        <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 text-slate-900 dark:text-slate-100 relative overflow-hidden transition-colors duration-300">
             {/* Decorative background elements */}
-            <div className="absolute top-0 right-0 w-[600px] h-[600px] bg-gradient-to-br from-sky-100/40 to-indigo-100/40 rounded-full blur-3xl -translate-y-1/2 translate-x-1/3 pointer-events-none" />
-            <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-gradient-to-tr from-violet-100/30 to-pink-100/30 rounded-full blur-3xl translate-y-1/2 -translate-x-1/3 pointer-events-none" />
+            <div className="absolute top-0 right-0 w-[600px] h-[600px] bg-gradient-to-br from-sky-100/40 to-indigo-100/40 dark:from-sky-900/20 dark:to-indigo-900/20 rounded-full blur-3xl -translate-y-1/2 translate-x-1/3 pointer-events-none" />
+            <div className="absolute bottom-0 left-0 w-[500px] h-[500px] bg-gradient-to-tr from-violet-100/30 to-pink-100/30 dark:from-violet-900/20 dark:to-pink-900/20 rounded-full blur-3xl translate-y-1/2 -translate-x-1/3 pointer-events-none" />
             
             <div className="max-w-7xl mx-auto px-6 md:px-8 pt-8 md:pt-12 pb-20 relative z-10">
                 {/* Header */}
                 <header className="flex items-center justify-between mb-12 md:mb-20">
                     <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-sky-200">
+                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-500 to-indigo-600 flex items-center justify-center shadow-lg shadow-sky-200 dark:shadow-sky-900/50">
                             <Sparkles className="w-5 h-5 text-white" />
                         </div>
-                        <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 bg-clip-text text-transparent">Node Speak v3.3</h1>
+                        <h1 className="text-xl md:text-2xl font-bold bg-gradient-to-r from-slate-900 to-slate-700 dark:from-slate-100 dark:to-slate-300 bg-clip-text text-transparent">Node Speak v3.3</h1>
                     </div>
-                    <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-3">
+                        <ThemeToggle />
                         <WalletConnect />
                     </div>
                 </header>
@@ -114,21 +116,21 @@ function Landing() {
                 <main className="grid gap-8 lg:gap-12 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)] items-start">
                     <section className="space-y-8">
                         {/* Main Hero Card */}
-                        <div className="group relative bg-white/80 backdrop-blur-xl rounded-[2rem] shadow-2xl shadow-slate-200/50 border border-white/60 px-8 md:px-12 py-10 md:py-14 overflow-hidden transition-all duration-500 hover:shadow-slate-300/60">
+                        <div className="group relative bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-[2rem] shadow-2xl shadow-slate-200/50 dark:shadow-slate-900/50 border border-white/60 dark:border-slate-700/60 px-8 md:px-12 py-10 md:py-14 overflow-hidden transition-all duration-500 hover:shadow-slate-300/60 dark:hover:shadow-slate-900/80">
                             {/* Subtle gradient overlay on hover */}
-                            <div className="absolute inset-0 bg-gradient-to-br from-sky-50/0 to-indigo-50/0 group-hover:from-sky-50/50 group-hover:to-indigo-50/30 transition-all duration-500 rounded-[2rem]" />
+                            <div className="absolute inset-0 bg-gradient-to-br from-sky-50/0 to-indigo-50/0 group-hover:from-sky-50/50 group-hover:to-indigo-50/30 dark:group-hover:from-sky-900/20 dark:group-hover:to-indigo-900/20 transition-all duration-500 rounded-[2rem]" />
                             
                             <div className="relative z-10">
-                                <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-[3.25rem] font-bold tracking-tight text-slate-900 mb-6 leading-[1.1]">
+                                <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-[3.25rem] font-bold tracking-tight text-slate-900 dark:text-slate-100 mb-6 leading-[1.1]">
                                     The Decentralized and Immutable Forum
                                 </h2>
-                                <p className="text-base md:text-lg text-slate-600 max-w-xl mb-8 leading-relaxed">
+                                <p className="text-base md:text-lg text-slate-600 dark:text-slate-300 max-w-xl mb-8 leading-relaxed">
                                     Node Speak is a platform that redefines online forums by using blockchain technology and decentralized storage. Designed to ensure permanence, transparency and resistance to censorship.
                                 </p>
                                 <div className="flex flex-wrap items-center gap-4 mb-10">
                                     <button 
                                         onClick={handleExplore}
-                                        className="group/btn relative inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-slate-900 to-slate-800 text-white font-medium text-sm shadow-lg shadow-slate-300 hover:shadow-xl hover:shadow-slate-400/50 transition-all duration-300 hover:-translate-y-0.5"
+                                        className="group/btn relative inline-flex items-center gap-2 px-6 py-3 rounded-full bg-gradient-to-r from-slate-900 to-slate-800 dark:from-sky-500 dark:to-indigo-600 text-white font-medium text-sm shadow-lg shadow-slate-300 dark:shadow-sky-900/50 hover:shadow-xl hover:shadow-slate-400/50 dark:hover:shadow-sky-700/50 transition-all duration-300 hover:-translate-y-0.5"
                                     >
                                         <span>Explore Forum</span>
                                         <svg className="w-4 h-4 transition-transform group-hover/btn:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -139,31 +141,31 @@ function Landing() {
 
                                 {/* Feature Cards */}
                                 <div className="grid gap-4 sm:grid-cols-3">
-                                    <div className="group/card relative rounded-2xl border border-slate-100 bg-gradient-to-br from-white to-slate-50/80 p-5 transition-all duration-300 hover:border-sky-200 hover:shadow-lg hover:shadow-sky-100/50 hover:-translate-y-1">
-                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-100 to-sky-50 flex items-center justify-center mb-3 group-hover/card:from-sky-200 group-hover/card:to-sky-100 transition-colors">
-                                            <Users className="w-5 h-5 text-sky-600" />
+                                    <div className="group/card relative rounded-2xl border border-slate-100 dark:border-slate-700 bg-gradient-to-br from-white to-slate-50/80 dark:from-slate-800 dark:to-slate-900/80 p-5 transition-all duration-300 hover:border-sky-200 dark:hover:border-sky-700 hover:shadow-lg hover:shadow-sky-100/50 dark:hover:shadow-sky-900/30 hover:-translate-y-1">
+                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-sky-100 to-sky-50 dark:from-sky-900/50 dark:to-sky-800/50 flex items-center justify-center mb-3 group-hover/card:from-sky-200 group-hover/card:to-sky-100 dark:group-hover/card:from-sky-800/50 dark:group-hover/card:to-sky-700/50 transition-colors">
+                                            <Users className="w-5 h-5 text-sky-600 dark:text-sky-400" />
                                         </div>
-                                        <p className="font-semibold text-slate-900 mb-1.5">Communities</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 mb-1.5">Communities</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
                                             Create and manage discussion topics.
                                             Follow profiles of interest.
                                         </p>
                                     </div>
-                                    <div className="group/card relative rounded-2xl border border-slate-100 bg-gradient-to-br from-white to-slate-50/80 p-5 transition-all duration-300 hover:border-violet-200 hover:shadow-lg hover:shadow-violet-100/50 hover:-translate-y-1">
-                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-violet-100 to-violet-50 flex items-center justify-center mb-3 group-hover/card:from-violet-200 group-hover/card:to-violet-100 transition-colors">
-                                            <MessageSquare className="w-5 h-5 text-violet-600" />
+                                    <div className="group/card relative rounded-2xl border border-slate-100 dark:border-slate-700 bg-gradient-to-br from-white to-slate-50/80 dark:from-slate-800 dark:to-slate-900/80 p-5 transition-all duration-300 hover:border-violet-200 dark:hover:border-violet-700 hover:shadow-lg hover:shadow-violet-100/50 dark:hover:shadow-violet-900/30 hover:-translate-y-1">
+                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-violet-100 to-violet-50 dark:from-violet-900/50 dark:to-violet-800/50 flex items-center justify-center mb-3 group-hover/card:from-violet-200 group-hover/card:to-violet-100 dark:group-hover/card:from-violet-800/50 dark:group-hover/card:to-violet-700/50 transition-colors">
+                                            <MessageSquare className="w-5 h-5 text-violet-600 dark:text-violet-400" />
                                         </div>
-                                        <p className="font-semibold text-slate-900 mb-1.5">Posts & Threads</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 mb-1.5">Posts & Threads</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
                                             Post messages and reply to other participants.
                                         </p>
                                     </div>
-                                    <div className="group/card relative rounded-2xl border border-slate-100 bg-gradient-to-br from-white to-slate-50/80 p-5 transition-all duration-300 hover:border-emerald-200 hover:shadow-lg hover:shadow-emerald-100/50 hover:-translate-y-1">
-                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-100 to-emerald-50 flex items-center justify-center mb-3 group-hover/card:from-emerald-200 group-hover/card:to-emerald-100 transition-colors">
-                                            <Shield className="w-5 h-5 text-emerald-600" />
+                                    <div className="group/card relative rounded-2xl border border-slate-100 dark:border-slate-700 bg-gradient-to-br from-white to-slate-50/80 dark:from-slate-800 dark:to-slate-900/80 p-5 transition-all duration-300 hover:border-emerald-200 dark:hover:border-emerald-700 hover:shadow-lg hover:shadow-emerald-100/50 dark:hover:shadow-emerald-900/30 hover:-translate-y-1">
+                                        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-100 to-emerald-50 dark:from-emerald-900/50 dark:to-emerald-800/50 flex items-center justify-center mb-3 group-hover/card:from-emerald-200 group-hover/card:to-emerald-100 dark:group-hover/card:from-emerald-800/50 dark:group-hover/card:to-emerald-700/50 transition-colors">
+                                            <Shield className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
                                         </div>
-                                        <p className="font-semibold text-slate-900 mb-1.5">Admin Mode (In progress)</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 mb-1.5">Admin Mode (In progress)</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">
                                             Moderate, curate, and protect spaces in one interface.
                                         </p>
                                     </div>
@@ -174,57 +176,57 @@ function Landing() {
 
                     {/* Sidebar */}
                     <aside className="space-y-5">
-                        <div className="relative bg-white/80 backdrop-blur-xl rounded-2xl shadow-xl shadow-slate-200/40 border border-white/60 px-7 py-8 overflow-hidden">
+                        <div className="relative bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-2xl shadow-xl shadow-slate-200/40 dark:shadow-slate-900/40 border border-white/60 dark:border-slate-700/60 px-7 py-8 overflow-hidden">
                             {/* Decorative accent */}
                             <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-sky-400 via-indigo-500 to-violet-500" />
                             
                             <div className="flex items-center gap-2 mb-5">
-                                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-100 to-indigo-50 flex items-center justify-center">
-                                    <Sparkles className="w-4 h-4 text-indigo-600" />
+                                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-100 to-indigo-50 dark:from-indigo-900/50 dark:to-indigo-800/50 flex items-center justify-center">
+                                    <Sparkles className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
                                 </div>
-                                <p className="text-sm font-bold tracking-wide text-slate-800 uppercase">
+                                <p className="text-sm font-bold tracking-wide text-slate-800 dark:text-slate-200 uppercase">
                                     Key Features
                                 </p>
                             </div>
                             
                             <div className="space-y-4">
-                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent hover:from-sky-50 transition-colors">
-                                    <div className="w-9 h-9 rounded-lg bg-sky-100 flex items-center justify-center flex-shrink-0">
-                                        <Lock className="w-4 h-4 text-sky-600" />
+                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent dark:from-slate-700/50 dark:to-transparent hover:from-sky-50 dark:hover:from-sky-900/30 transition-colors">
+                                    <div className="w-9 h-9 rounded-lg bg-sky-100 dark:bg-sky-900/50 flex items-center justify-center flex-shrink-0">
+                                        <Lock className="w-4 h-4 text-sky-600 dark:text-sky-400" />
                                     </div>
                                     <div>
-                                        <p className="font-semibold text-slate-900 text-sm mb-0.5">Blockchain and Security:</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">All messages are backed by blockchain technology, ensuring transparency and reliability.</p>
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm mb-0.5">Blockchain and Security:</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">All messages are backed by blockchain technology, ensuring transparency and reliability.</p>
                                     </div>
                                 </div>
                                 
-                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent hover:from-violet-50 transition-colors">
-                                    <div className="w-9 h-9 rounded-lg bg-violet-100 flex items-center justify-center flex-shrink-0">
-                                        <Database className="w-4 h-4 text-violet-600" />
+                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent dark:from-slate-700/50 dark:to-transparent hover:from-violet-50 dark:hover:from-violet-900/30 transition-colors">
+                                    <div className="w-9 h-9 rounded-lg bg-violet-100 dark:bg-violet-900/50 flex items-center justify-center flex-shrink-0">
+                                        <Database className="w-4 h-4 text-violet-600 dark:text-violet-400" />
                                     </div>
                                     <div>
-                                        <p className="font-semibold text-slate-900 text-sm mb-0.5">Permanent Storage:</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">We use IPFS (InterPlanetary File System) to ensure data is accessible in a decentralized and immutable way.</p>
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm mb-0.5">Permanent Storage:</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">We use IPFS (InterPlanetary File System) to ensure data is accessible in a decentralized and immutable way.</p>
                                     </div>
                                 </div>
                                 
-                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent hover:from-emerald-50 transition-colors">
-                                    <div className="w-9 h-9 rounded-lg bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                                        <Globe className="w-4 h-4 text-emerald-600" />
+                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent dark:from-slate-700/50 dark:to-transparent hover:from-emerald-50 dark:hover:from-emerald-900/30 transition-colors">
+                                    <div className="w-9 h-9 rounded-lg bg-emerald-100 dark:bg-emerald-900/50 flex items-center justify-center flex-shrink-0">
+                                        <Globe className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />
                                     </div>
                                     <div>
-                                        <p className="font-semibold text-slate-900 text-sm mb-0.5">No Censorship or Arbitrary Moderation:</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">Content is always available and moderated by each community running a version of NodeSpeak.</p>
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm mb-0.5">No Censorship or Arbitrary Moderation:</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">Content is always available and moderated by each community running a version of NodeSpeak.</p>
                                     </div>
                                 </div>
                                 
-                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent hover:from-amber-50 transition-colors">
-                                    <div className="w-9 h-9 rounded-lg bg-amber-100 flex items-center justify-center flex-shrink-0">
-                                        <Shield className="w-4 h-4 text-amber-600" />
+                                <div className="flex gap-3 p-3 rounded-xl bg-gradient-to-r from-slate-50 to-transparent dark:from-slate-700/50 dark:to-transparent hover:from-amber-50 dark:hover:from-amber-900/30 transition-colors">
+                                    <div className="w-9 h-9 rounded-lg bg-amber-100 dark:bg-amber-900/50 flex items-center justify-center flex-shrink-0">
+                                        <Shield className="w-4 h-4 text-amber-600 dark:text-amber-400" />
                                     </div>
                                     <div>
-                                        <p className="font-semibold text-slate-900 text-sm mb-0.5">Secure Content:</p>
-                                        <p className="text-slate-500 text-sm leading-relaxed">Persistent storage ensures content is protected against external manipulations.</p>
+                                        <p className="font-semibold text-slate-900 dark:text-slate-100 text-sm mb-0.5">Secure Content:</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm leading-relaxed">Persistent storage ensures content is protected against external manipulations.</p>
                                     </div>
                                 </div>
                             </div>
@@ -233,8 +235,8 @@ function Landing() {
                 </main>
 
                 {/* Footer */}
-                <footer className="mt-20 md:mt-28 border-t border-slate-200/60 pt-10 flex flex-col md:flex-row items-center justify-between gap-6">
-                    <p className="text-base text-slate-500">
+                <footer className="mt-20 md:mt-28 border-t border-slate-200/60 dark:border-slate-700/60 pt-10 flex flex-col md:flex-row items-center justify-between gap-6">
+                    <p className="text-base text-slate-500 dark:text-slate-400">
                         &copy; {new Date().getFullYear()} NodeSpeak. Built for decentralized communities.
                     </p>
                     <div className="flex flex-wrap gap-3">
@@ -242,7 +244,7 @@ function Landing() {
                             href="https://github.com/NodeSpeak/NodeSpeakv1.1-main"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center rounded-full bg-slate-900 text-white px-5 py-2.5 text-sm font-medium shadow-lg shadow-slate-300/50 hover:bg-slate-800 hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300"
+                            className="inline-flex items-center rounded-full bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 px-5 py-2.5 text-sm font-medium shadow-lg shadow-slate-300/50 dark:shadow-slate-900/50 hover:bg-slate-800 dark:hover:bg-white hover:shadow-xl hover:-translate-y-0.5 transition-all duration-300"
                         >
                             <Github className="w-4 h-4 mr-2" />
                             GitHub
@@ -251,14 +253,14 @@ function Landing() {
                             href="https://twitter.com/NodeSpeak"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="inline-flex items-center rounded-full bg-white text-slate-700 px-5 py-2.5 text-sm font-medium border border-slate-200 shadow-sm hover:bg-slate-50 hover:border-slate-300 hover:-translate-y-0.5 transition-all duration-300"
+                            className="inline-flex items-center rounded-full bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 px-5 py-2.5 text-sm font-medium border border-slate-200 dark:border-slate-600 shadow-sm hover:bg-slate-50 dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-slate-500 hover:-translate-y-0.5 transition-all duration-300"
                         >
                             <X className="w-4 h-4 mr-2" />
                             @NodeSpeak
                         </a>
                         <a
                             href="mailto:support@nodespeak.xyz"
-                            className="inline-flex items-center rounded-full bg-white text-slate-700 px-5 py-2.5 text-sm font-medium border border-slate-200 shadow-sm hover:bg-slate-50 hover:border-slate-300 hover:-translate-y-0.5 transition-all duration-300"
+                            className="inline-flex items-center rounded-full bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 px-5 py-2.5 text-sm font-medium border border-slate-200 dark:border-slate-600 shadow-sm hover:bg-slate-50 dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-slate-500 hover:-translate-y-0.5 transition-all duration-300"
                         >
                             <Mail className="w-4 h-4 mr-2" />
                             Support

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -8,6 +8,7 @@ import { useProfileService } from "@/lib/profileService";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { User, ArrowLeft, Edit3, MessageSquare, Heart, UserPlus, UserCheck, Shield, EyeOff } from "lucide-react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { BrowserProvider, Contract } from "ethers";
 import { forumAddress, forumABI } from "@/contracts/DecentralizedForum_V3.3";
 
@@ -439,9 +440,9 @@ export default function ProfilePage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] flex items-center justify-center">
-        <div className="flex flex-col items-center bg-white/90 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-slate-200">
-          <p className="text-lg text-slate-700 font-medium">Loading profile...</p>
+      <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 flex items-center justify-center">
+        <div className="flex flex-col items-center bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl p-8 shadow-lg border border-slate-200 dark:border-slate-700">
+          <p className="text-lg text-slate-700 dark:text-slate-200 font-medium">Loading profile...</p>
           <div className="mt-4 flex space-x-2">
             <div className="h-2 w-2 bg-sky-500 rounded-full animate-pulse"></div>
             <div className="h-2 w-2 bg-sky-500 rounded-full animate-pulse delay-150"></div>
@@ -453,21 +454,31 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff]">
+    <div className="min-h-screen bg-gradient-to-br from-[#f5f7ff] via-[#fdfbff] to-[#e6f0ff] dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
       <div className="max-w-4xl mx-auto px-6 py-8">
+        {/* Back to forum link */}
+        <div className="mb-6">
+          <Link 
+            href="/foro" 
+            className="inline-flex items-center text-sm text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Forum
+          </Link>
+        </div>
         {/* Banner if no profile exists */}
         {!profileExists && isOwnProfile && (
-          <div className="mb-6 rounded-2xl bg-amber-50 border border-amber-200 p-5">
+          <div className="mb-6 rounded-2xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-5">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-amber-700 font-semibold">⚠️ Profile not found on blockchain</p>
-                <p className="text-amber-600 text-sm mt-1">
+                <p className="text-amber-700 dark:text-amber-300 font-semibold">⚠️ Profile not found on blockchain</p>
+                <p className="text-amber-600 dark:text-amber-400 text-sm mt-1">
                   Create your on-chain profile to personalize your NodeSpeak experience.
                 </p>
               </div>
               <Button 
                 onClick={() => router.push('/profile/edit')}
-                className="bg-amber-100 hover:bg-amber-200 text-amber-700 border border-amber-300 rounded-full px-4"
+                className="bg-amber-100 hover:bg-amber-200 text-amber-700 border border-amber-300 rounded-full px-4 dark:bg-amber-900/40 dark:hover:bg-amber-900/60 dark:text-amber-200 dark:border-amber-700"
               >
                 <Edit3 className="h-4 w-4 mr-2" />
                 Create Profile
@@ -477,17 +488,17 @@ export default function ProfilePage() {
         )}
         
         {!profileExists && !isOwnProfile && (
-          <div className="mb-6 rounded-2xl bg-sky-50 border border-sky-200 p-5">
-            <p className="text-sky-700">
+          <div className="mb-6 rounded-2xl bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800 p-5">
+            <p className="text-sky-700 dark:text-sky-300">
               This user hasn't created a profile yet. You can still follow them.
             </p>
           </div>
         )}
 
         {/* Profile Header with Cover Photo Background */}
-        <div className="mb-6 rounded-2xl border border-slate-200 shadow-sm overflow-hidden relative">
+        <div className="mb-6 rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm overflow-hidden relative">
           {/* Cover Photo as Full Background */}
-          <div className="absolute inset-0 bg-gradient-to-br from-sky-100 to-indigo-100">
+          <div className="absolute inset-0 bg-gradient-to-br from-sky-100 to-indigo-100 dark:from-slate-800 dark:to-slate-700">
             {profileData.coverPhoto && (
               <img 
                 src={profileData.coverPhoto} 
@@ -495,7 +506,7 @@ export default function ProfilePage() {
                 className="w-full h-full object-cover"
               />
             )}
-            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/5 to-white/30"></div>
+            <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/5 to-white/30 dark:via-slate-900/10 dark:to-slate-900/40"></div>
           </div>
           
           {/* Profile Content - Overlaid on cover */}
@@ -504,7 +515,7 @@ export default function ProfilePage() {
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               {/* Avatar Section */}
               <div className="flex justify-center md:justify-start">
-                <div className="w-28 h-28 md:w-32 md:h-32 rounded-2xl overflow-hidden border-4 border-white shadow-xl bg-slate-50">
+                <div className="w-28 h-28 md:w-32 md:h-32 rounded-2xl overflow-hidden border-4 border-white dark:border-slate-800 shadow-xl bg-slate-50 dark:bg-slate-700">
                   {profileData.profilePicture ? (
                     <img 
                       src={profileData.profilePicture} 
@@ -513,7 +524,7 @@ export default function ProfilePage() {
                     />
                   ) : (
                     <div className="h-full w-full flex items-center justify-center">
-                      <User className="h-14 w-14 text-slate-400" />
+                      <User className="h-14 w-14 text-slate-400 dark:text-slate-500" />
                     </div>
                   )}
                 </div>
@@ -521,10 +532,10 @@ export default function ProfilePage() {
             </div>
             
             {/* Action buttons */}
-            <div className="flex justify-between mt-6 pt-4 border-t border-white/20">
+            <div className="flex justify-between mt-6 pt-4 border-t border-white/20 dark:border-slate-700">
             <Button 
               onClick={() => router.push('/foro')}
-              className="bg-white/90 backdrop-blur-sm border border-white/50 text-slate-700 hover:bg-white rounded-full px-4 text-sm shadow-lg"
+              className="bg-white/90 backdrop-blur-sm border border-white/50 text-slate-700 hover:bg-white rounded-full px-4 text-sm shadow-lg dark:bg-slate-800 dark:hover:bg-slate-700 dark:text-slate-200 dark:border-slate-600"
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
               Back to Forum
@@ -534,7 +545,7 @@ export default function ProfilePage() {
               {isOwnProfile ? (
                 <Button 
                   onClick={() => router.push('/profile/edit')}
-                  className="bg-slate-900 text-white hover:bg-slate-800 rounded-full px-4 text-sm shadow-lg"
+                  className="bg-slate-100 hover:bg-slate-200 text-slate-700 border border-slate-200 rounded-full px-4 dark:bg-slate-700 dark:hover:bg-slate-600 dark:text-slate-200 dark:border-slate-600"
                 >
                   <Edit3 className="h-4 w-4 mr-2" />
                   Edit Profile
@@ -545,8 +556,8 @@ export default function ProfilePage() {
                   disabled={followLoading || !profileExists}
                   title={!profileExists ? 'This user has not created a profile yet' : ''}
                   className={`rounded-full px-4 text-sm shadow-lg ${isFollowing 
-                    ? 'bg-red-50 text-red-600 border border-red-200 hover:bg-red-100' 
-                    : 'bg-slate-900 text-white hover:bg-slate-800'} disabled:opacity-50 disabled:cursor-not-allowed`}
+                    ? 'bg-red-50 text-red-600 border border-red-200 hover:bg-red-100 dark:bg-red-900 dark:hover:bg-red-800 dark:text-red-200 dark:border-red-700'
+                    : 'bg-indigo-600 hover:bg-indigo-700 text-white dark:bg-indigo-500 dark:hover:bg-indigo-400'} disabled:opacity-50 disabled:cursor-not-allowed`}
                 >
                   {followLoading ? (
                     <span className="animate-pulse">...</span>
@@ -605,62 +616,62 @@ export default function ProfilePage() {
         </div>
 
         {/* User Details - Outside main card */}
-        <div className="mt-4 mb-6 bg-white/90 backdrop-blur-sm rounded-2xl p-5 border border-slate-200 shadow-sm">
+        <div className="mt-4 mb-6 bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl p-5 border border-slate-200 dark:border-slate-700 shadow-sm">
           <div className="grid grid-cols-1 gap-3">
             <div className="flex">
-              <span className="text-slate-500 w-32 text-sm">Nickname</span>
-              <span className="text-slate-900 font-medium">{displayName}</span>
+              <span className="text-slate-500 dark:text-slate-400 w-32 text-sm">Nickname</span>
+              <span className="text-slate-900 dark:text-slate-100 font-medium">{displayName}</span>
             </div>
             <div className="flex">
-              <span className="text-slate-500 w-32 text-sm">Address</span>
-              <span className="text-slate-700 font-mono text-sm">{fullAddress}</span>
+              <span className="text-slate-500 dark:text-slate-400 w-32 text-sm">Address</span>
+              <span className="text-slate-700 dark:text-slate-300 font-mono text-sm">{fullAddress}</span>
             </div>
             <div className="flex">
-              <span className="text-slate-500 w-32 text-sm">Status</span>
-              <span className="px-2 py-0.5 bg-emerald-100 text-emerald-700 text-xs rounded-full">Active</span>
+              <span className="text-slate-500 dark:text-slate-400 w-32 text-sm">Status</span>
+              <span className="px-2 py-0.5 bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs rounded-full">Active</span>
             </div>
             <div className="flex">
-              <span className="text-slate-500 w-32 text-sm">Member since</span>
-              <span className="text-slate-700">{profileData.memberSince}</span>
+              <span className="text-slate-500 dark:text-slate-400 w-32 text-sm">Member since</span>
+              <span className="text-slate-700 dark:text-slate-300">{profileData.memberSince}</span>
             </div>
             <div className="flex">
-              <span className="text-slate-500 w-32 text-sm">Posts</span>
-              <span className="text-slate-900 font-medium">{profileData.postCount}</span>
+              <span className="text-slate-500 dark:text-slate-400 w-32 text-sm">Posts</span>
+              <span className="text-slate-900 dark:text-slate-100 font-medium">{profileData.postCount}</span>
             </div>
-            <div className="mt-2 border-t border-slate-200 pt-3">
-              <span className="text-slate-500 text-sm">Bio</span>
-              <p className="text-slate-700 mt-1">{profileData.bio}</p>
+            <div className="mt-2 border-t border-slate-200 dark:border-slate-700 pt-3">
+              <span className="text-slate-500 dark:text-slate-400 text-sm">Bio</span>
+              <p className="text-slate-700 dark:text-slate-300 mt-1">{profileData.bio}</p>
             </div>
           </div>
         </div>
         
         {/* Stats Section - Outside card */}
         <div className="mb-6">
-          <h2 className="text-lg font-semibold text-slate-900 mb-3">Statistics</h2>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-3">Statistics</h2>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-slate-200 p-5 shadow-sm">
-              <p className="text-xs text-slate-500 mb-1">Likes Received</p>
-              <p className="text-2xl font-semibold text-slate-900">{profileData.likesReceived}</p>
+            <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-xl border border-slate-200 dark:border-slate-700 p-5 shadow-sm">
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Likes Received</p>
+              <p className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{profileData.likesReceived}</p>
             </div>
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-slate-200 p-5 shadow-sm">
-              <p className="text-xs text-slate-500 mb-1">Likes Given</p>
-              <p className="text-2xl font-semibold text-slate-900">{profileData.likesGiven}</p>
+            <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-xl border border-slate-200 dark:border-slate-700 p-5 shadow-sm">
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Likes Given</p>
+              <p className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{profileData.likesGiven}</p>
             </div>
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-slate-200 p-5 shadow-sm">
-              <p className="text-xs text-slate-500 mb-1">Followers</p>
-              <p className="text-2xl font-semibold text-slate-900">{profileData.followers}</p>
+            <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-xl border border-slate-200 dark:border-slate-700 p-5 shadow-sm">
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Followers</p>
+              <p className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{profileData.followers}</p>
             </div>
-            <div className="bg-white/90 backdrop-blur-sm rounded-xl border border-slate-200 p-5 shadow-sm">
-              <p className="text-xs text-slate-500 mb-1">Following</p>
-              <p className="text-2xl font-semibold text-slate-900">{profileData.following}</p>
+            <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-xl border border-slate-200 dark:border-slate-700 p-5 shadow-sm">
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-1">Following</p>
+              <p className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{profileData.following}</p>
             </div>
           </div>
         </div>
 
         {/* Communities Section */}
-        <div className="bg-white/90 backdrop-blur-sm rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
-          <div className="px-6 py-4 border-b border-slate-200">
-            <h2 className="text-lg font-semibold text-slate-900">Communities</h2>
+        <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-700">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Communities</h2>
           </div>
           
           <div className="p-4">
@@ -670,9 +681,9 @@ export default function ProfilePage() {
                   <Link 
                     key={community.id}
                     href={`/foro?community=${community.id}`}
-                    className="flex items-center gap-3 p-3 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors cursor-pointer"
+                    className="flex items-center gap-3 p-3 bg-slate-50 dark:bg-slate-700 rounded-xl hover:bg-slate-100 dark:hover:bg-slate-600 transition-colors cursor-pointer"
                   >
-                    <div className="w-10 h-10 rounded-lg overflow-hidden bg-slate-200 flex-shrink-0">
+                    <div className="w-10 h-10 rounded-lg overflow-hidden bg-slate-200 dark:bg-slate-600 flex-shrink-0">
                       {community.photo ? (
                         <img 
                           src={`https://gateway.pinata.cloud/ipfs/${community.photo}`}
@@ -690,7 +701,7 @@ export default function ProfilePage() {
                               const parent = img.parentElement;
                               if (parent && !parent.querySelector('.fallback-initial')) {
                                 const fallback = document.createElement('div');
-                                fallback.className = 'fallback-initial w-full h-full flex items-center justify-center text-slate-400 text-sm font-medium';
+                                fallback.className = 'fallback-initial w-full h-full flex items-center justify-center text-slate-400 dark:text-slate-300 text-sm font-medium';
                                 fallback.textContent = community.name.charAt(0).toUpperCase();
                                 parent.appendChild(fallback);
                               }
@@ -698,65 +709,65 @@ export default function ProfilePage() {
                           }}
                         />
                       ) : (
-                        <div className="w-full h-full flex items-center justify-center text-slate-400 text-sm font-medium">
+                        <div className="w-full h-full flex items-center justify-center text-slate-400 dark:text-slate-300 text-sm font-medium">
                           {community.name.charAt(0).toUpperCase()}
                         </div>
                       )}
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium text-slate-900 truncate">{community.name}</p>
-                      <p className="text-xs text-slate-500">{community.memberCount} members</p>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">{community.name}</p>
+                      <p className="text-xs text-slate-500 dark:text-slate-400">{community.memberCount} members</p>
                     </div>
                   </Link>
                 ))}
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-8">
-                <User className="h-10 w-10 text-slate-300 mb-3" />
-                <p className="text-slate-500 text-sm">Not a member of any community yet</p>
+                <User className="h-10 w-10 text-slate-300 dark:text-slate-600 mb-3" />
+                <p className="text-slate-500 dark:text-slate-400 text-sm">Not a member of any community yet</p>
               </div>
             )}
           </div>
         </div>
 
         {/* Recent Activity Section */}
-        <div className="bg-white/90 backdrop-blur-sm rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
-          <div className="px-6 py-4 border-b border-slate-200">
-            <h2 className="text-lg font-semibold text-slate-900">Recent Activity</h2>
+        <div className="bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-700">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Recent Activity</h2>
           </div>
           
           <div className="min-h-[200px]">
             {recentActivity.length > 0 ? (
-              <div className="divide-y divide-slate-100">
+              <div className="divide-y divide-slate-100 dark:divide-slate-700">
                 {recentActivity.map((activity, index) => (
-                  <div key={index} className="p-4 hover:bg-slate-50 transition-colors">
+                  <div key={index} className="p-4 hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors">
                     <div className="flex items-start space-x-3">
-                      <div className="mt-1 p-2 bg-slate-100 rounded-full">
-                        {activity.type === 'post' && <MessageSquare className="h-4 w-4 text-indigo-600" />}
-                        {activity.type === 'comment' && <MessageSquare className="h-4 w-4 text-emerald-600" />}
+                      <div className="mt-1 p-2 bg-slate-100 dark:bg-slate-700 rounded-full">
+                        {activity.type === 'post' && <MessageSquare className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />}
+                        {activity.type === 'comment' && <MessageSquare className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />}
                       </div>
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
                           <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
                             activity.type === 'post' 
-                              ? 'bg-indigo-100 text-indigo-700' 
-                              : 'bg-emerald-100 text-emerald-700'
+                              ? 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' 
+                              : 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
                           }`}>
                             {activity.type === 'post' ? 'Post' : 'Comment'}
                           </span>
-                          <span className="text-slate-500 text-xs">in</span>
-                          <span className="text-slate-700 text-xs font-medium">{activity.communityName}</span>
+                          <span className="text-slate-500 dark:text-slate-400 text-xs">in</span>
+                          <span className="text-slate-700 dark:text-slate-300 text-xs font-medium">{activity.communityName}</span>
                           {activity.topic && (
                             <>
-                              <span className="text-slate-400 text-xs">•</span>
-                              <span className="text-slate-500 text-xs">{activity.topic}</span>
+                              <span className="text-slate-400 dark:text-slate-500 text-xs">•</span>
+                              <span className="text-slate-500 dark:text-slate-400 text-xs">{activity.topic}</span>
                             </>
                           )}
                         </div>
-                        <p className="text-slate-700 text-sm mt-1">
+                        <p className="text-slate-700 dark:text-slate-300 text-sm mt-1">
                           {activity.content}
                         </p>
-                        <p className="text-slate-400 text-xs mt-2">
+                        <p className="text-slate-400 dark:text-slate-500 text-xs mt-2">
                           {new Date(activity.timestamp).toLocaleString()}
                         </p>
                       </div>
@@ -766,9 +777,9 @@ export default function ProfilePage() {
               </div>
             ) : (
               <div className="flex flex-col items-center justify-center py-12">
-                <MessageSquare className="h-12 w-12 text-slate-300 mb-4" />
-                <p className="text-slate-500">No activity to display yet.</p>
-                <p className="text-slate-400 text-sm mt-2">Start posting to see your activity here!</p>
+                <MessageSquare className="h-12 w-12 text-slate-300 dark:text-slate-600 mb-4" />
+                <p className="text-slate-500 dark:text-slate-400">No activity to display yet.</p>
+                <p className="text-slate-400 dark:text-slate-500 text-sm mt-2">Start posting to see your activity here!</p>
               </div>
             )}
           </div>

--- a/components/IntegratedView.tsx
+++ b/components/IntegratedView.tsx
@@ -111,7 +111,7 @@ const MatrixEditor = ({ content, setContent }: { content: string; setContent: Re
         },
         editorProps: {
             attributes: {
-                class: 'bg-white border border-slate-200 text-slate-900 p-4 rounded-xl focus:outline-none focus:ring-2 focus:ring-sky-200 focus:border-sky-400 min-h-[150px] prose prose-sm max-w-none',
+                class: 'bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 p-4 rounded-xl focus:outline-none focus:ring-2 focus:ring-sky-200 dark:focus:ring-sky-800 focus:border-sky-400 dark:focus:border-sky-600 min-h-[150px] prose prose-sm dark:prose-invert max-w-none',
             },
         },
     });
@@ -125,19 +125,19 @@ const MatrixEditor = ({ content, setContent }: { content: string; setContent: Re
             <div className="flex gap-2 mb-2 flex-wrap">
                 <button
                     onClick={() => editor.chain().focus().toggleBold().run()}
-                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('bold') ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50'}`}
+                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('bold') ? 'bg-slate-900 dark:bg-sky-500 text-white border-slate-900 dark:border-sky-500' : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600'}`}
                 >
                     Bold
                 </button>
                 <button
                     onClick={() => editor.chain().focus().toggleItalic().run()}
-                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('italic') ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50'}`}
+                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('italic') ? 'bg-slate-900 dark:bg-sky-500 text-white border-slate-900 dark:border-sky-500' : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600'}`}
                 >
                     Italic
                 </button>
                 <button
                     onClick={() => editor.chain().focus().toggleCode().run()}
-                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('code') ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50'}`}
+                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('code') ? 'bg-slate-900 dark:bg-sky-500 text-white border-slate-900 dark:border-sky-500' : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600'}`}
                 >
                     Code
                 </button>
@@ -148,13 +148,13 @@ const MatrixEditor = ({ content, setContent }: { content: string; setContent: Re
                             editor.chain().focus().setLink({ href: url }).run();
                         }
                     }}
-                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('link') ? 'bg-slate-900 text-white border-slate-900' : 'bg-white text-slate-700 border-slate-200 hover:bg-slate-50'}`}
+                    className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${editor.isActive('link') ? 'bg-slate-900 dark:bg-sky-500 text-white border-slate-900 dark:border-sky-500' : 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600'}`}
                 >
                     Link
                 </button>
                 <button
                     onClick={() => editor.chain().focus().unsetLink().run()}
-                    className="px-3 py-1.5 text-xs border rounded-lg transition-colors bg-white text-slate-700 border-slate-200 hover:bg-slate-50 disabled:opacity-50"
+                    className="px-3 py-1.5 text-xs border rounded-lg transition-colors bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-slate-200 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600 disabled:opacity-50"
                     disabled={!editor.isActive('link')}
                 >
                     Unlink
@@ -173,7 +173,7 @@ const FormattedContent = ({ htmlContent }: { htmlContent: string }) => {
 
     return (
         <div
-            className="post-content prose prose-sm max-w-none text-slate-700"
+            className="post-content prose prose-sm dark:prose-invert max-w-none text-slate-700 dark:text-slate-300"
             dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
         />
     );
@@ -1367,18 +1367,18 @@ export const IntegratedView = ({
 
     // Render Create Post Form
     const renderCreatePostForm = () => (
-        <div className="bg-white rounded-2xl border border-slate-100 p-6 shadow-sm">
-            <h2 className="text-xl font-semibold mb-6 text-slate-900">
+        <div className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-100 dark:border-slate-700 p-6 shadow-sm">
+            <h2 className="text-xl font-semibold mb-6 text-slate-900 dark:text-slate-100">
                 New Post
             </h2>
             <div className="space-y-5">
                 {/* Community Selector */}
                 <div className="flex flex-col">
-                    <label className="text-slate-600 font-medium mb-2 text-sm">Community</label>
+                    <label className="text-slate-600 dark:text-slate-300 font-medium mb-2 text-sm">Community</label>
                     <select
                         value={selectedCommunityId || ""}
                         onChange={handleCommunityChange}
-                        className="bg-slate-50 border border-slate-200 text-slate-900 p-3 rounded-xl w-full focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400"
+                        className="bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 p-3 rounded-xl w-full focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-800 focus:border-indigo-400 dark:focus:border-indigo-600"
                     >
                         <option value="" disabled>Select a community</option>
                         {communities.map(community => (
@@ -1391,13 +1391,13 @@ export const IntegratedView = ({
                             </option>
                         ))}
                     </select>
-                    <p className="text-xs text-slate-500 mt-1">You can only create posts in communities you have joined.</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">You can only create posts in communities you have joined.</p>
                 </div>
 
                 {/* Topic Selector */}
                 {selectedCommunityId && (
                     <div className="flex flex-col">
-                        <label className="text-slate-600 font-medium mb-2 text-sm">Topic</label>
+                        <label className="text-slate-600 dark:text-slate-300 font-medium mb-2 text-sm">Topic</label>
                         <TopicsDropdown
                             onTopicSelect={handleTopicChange}
                             topics={communityTopics}
@@ -1413,13 +1413,13 @@ export const IntegratedView = ({
 
                 {/* Post Content - Rich Text Editor */}
                 <div className="flex flex-col">
-                    <label className="text-slate-600 font-medium mb-2 text-sm">Content</label>
+                    <label className="text-slate-600 dark:text-slate-300 font-medium mb-2 text-sm">Content</label>
                     <MatrixEditor content={newPost} setContent={setNewPost} />
                 </div>
 
                 {/* Image Selector */}
                 <div className="flex flex-col">
-                    <label className="text-slate-600 font-medium mb-2 text-sm flex items-center">
+                    <label className="text-slate-600 dark:text-slate-300 font-medium mb-2 text-sm flex items-center">
                         <span>Attach Image</span>
                         <span className="ml-2 cursor-pointer">
                             <input
@@ -1430,12 +1430,12 @@ export const IntegratedView = ({
                                 id="image-upload"
                             />
                             <label htmlFor="image-upload" className="cursor-pointer">
-                                <ImagePlus className="h-4 w-4 text-slate-400 hover:text-indigo-500" />
+                                <ImagePlus className="h-4 w-4 text-slate-400 dark:text-slate-500 hover:text-indigo-500 dark:hover:text-indigo-400" />
                             </label>
                         </span>
                     </label>
                     {selectedImage && (
-                        <div className="mt-1 text-xs text-slate-500 p-3 border border-dashed border-slate-200 rounded-xl bg-slate-50">
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400 p-3 border border-dashed border-slate-200 dark:border-slate-600 rounded-xl bg-slate-50 dark:bg-slate-700">
                             {selectedImage.name}
                         </div>
                     )}
@@ -1445,13 +1445,13 @@ export const IntegratedView = ({
                 <div className="flex justify-end items-center gap-3 pt-4">
                     <Button
                         onClick={() => setIsCreatingPost(false)}
-                        className="bg-slate-100 border border-slate-200 text-slate-600 hover:bg-slate-200 rounded-xl px-5"
+                        className="bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-xl px-5"
                     >
                         Cancel
                     </Button>
                     <Button
                         onClick={handleSubmitPost}
-                        className="bg-indigo-600 text-white hover:bg-indigo-700 rounded-xl px-6 font-medium shadow-md shadow-indigo-200"
+                        className="bg-indigo-600 text-white hover:bg-indigo-700 rounded-xl px-6 font-medium shadow-md shadow-indigo-200 dark:shadow-indigo-900/50"
                         disabled={loading || !postSelectedTopic || !selectedCommunityId}
                     >
                         {loading ? (
@@ -1469,36 +1469,36 @@ export const IntegratedView = ({
 
     // Render Create Community Form
     const renderCreateCommunityForm = () => (
-        <div className="bg-white rounded-xl border border-slate-100 p-4 shadow-sm">
-            <h2 className="text-base font-semibold mb-3 text-slate-900">New Community</h2>
+        <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-100 dark:border-slate-700 p-4 shadow-sm">
+            <h2 className="text-base font-semibold mb-3 text-slate-900 dark:text-slate-100">New Community</h2>
             <form className="space-y-3">
                 {/* Name and Topics in a row on larger screens */}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                     <div className="flex flex-col">
-                        <label className="text-slate-600 font-medium mb-1 text-xs">Name</label>
+                        <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Name</label>
                         <input
                             type="text"
                             placeholder="Community name"
-                            className="bg-slate-50 border border-slate-200 text-slate-900 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400"
+                            className="bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-800 focus:border-indigo-400 dark:focus:border-indigo-600 placeholder:text-slate-400 dark:placeholder:text-slate-500"
                             id="community-name"
                         />
                     </div>
                     <div className="flex flex-col">
-                        <label className="text-slate-600 font-medium mb-1 text-xs">Topics</label>
+                        <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Topics</label>
                         <input
                             type="text"
                             placeholder="General, Tech, Blockchain"
-                            className="bg-slate-50 border border-slate-200 text-slate-900 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400"
+                            className="bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-800 focus:border-indigo-400 dark:focus:border-indigo-600 placeholder:text-slate-400 dark:placeholder:text-slate-500"
                             id="community-topics"
                         />
                     </div>
                 </div>
 
                 <div className="flex flex-col">
-                    <label className="text-slate-600 font-medium mb-1 text-xs">Description</label>
+                    <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Description</label>
                     <textarea
                         placeholder="What is this community about?"
-                        className="bg-slate-50 border border-slate-200 text-slate-900 px-3 py-2 rounded-lg h-16 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400 resize-none"
+                        className="bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 text-slate-900 dark:text-slate-100 px-3 py-2 rounded-lg h-16 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-800 focus:border-indigo-400 dark:focus:border-indigo-600 resize-none placeholder:text-slate-400 dark:placeholder:text-slate-500"
                         id="community-description"
                     />
                 </div>
@@ -1506,7 +1506,7 @@ export const IntegratedView = ({
                 {/* Logo and Cover side by side */}
                 <div className="grid grid-cols-2 gap-3">
                     <div className="flex flex-col">
-                        <label className="text-slate-600 font-medium mb-1 text-xs">Logo</label>
+                        <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Logo</label>
                         {communityLogoPreview ? (
                             <div className="relative group w-14 h-14">
                                 <img 
@@ -1558,7 +1558,7 @@ export const IntegratedView = ({
                     </div>
 
                     <div className="flex flex-col">
-                        <label className="text-slate-600 font-medium mb-1 text-xs">Cover</label>
+                        <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Cover</label>
                         {communityCoverPreview ? (
                             <div className="relative group">
                                 <img 
@@ -1612,9 +1612,9 @@ export const IntegratedView = ({
 
                 {/* Community Type Selector */}
                 <div className="flex flex-col">
-                    <label className="text-slate-600 font-medium mb-1 text-xs">Community Type</label>
+                    <label className="text-slate-600 dark:text-slate-300 font-medium mb-1 text-xs">Community Type</label>
                     <div className="flex gap-4">
-                        <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-slate-200 hover:border-indigo-300 hover:bg-indigo-50/50 transition-all has-[:checked]:border-indigo-400 has-[:checked]:bg-indigo-50">
+                        <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/30 transition-all has-[:checked]:border-indigo-400 dark:has-[:checked]:border-indigo-500 has-[:checked]:bg-indigo-50 dark:has-[:checked]:bg-indigo-900/40">
                             <input
                                 type="radio"
                                 name="community-type"
@@ -1622,23 +1622,23 @@ export const IntegratedView = ({
                                 defaultChecked
                                 className="accent-indigo-600 w-3.5 h-3.5"
                             />
-                            <Unlock className="w-4 h-4 text-green-500" />
+                            <Unlock className="w-4 h-4 text-green-500 dark:text-green-400" />
                             <div className="flex flex-col">
-                                <span className="text-sm font-medium text-slate-700">Open</span>
-                                <span className="text-[10px] text-slate-400">Anyone can view content</span>
+                                <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Open</span>
+                                <span className="text-[10px] text-slate-400 dark:text-slate-500">Anyone can view content</span>
                             </div>
                         </label>
-                        <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-slate-200 hover:border-indigo-300 hover:bg-indigo-50/50 transition-all has-[:checked]:border-indigo-400 has-[:checked]:bg-indigo-50">
+                        <label className="flex items-center gap-2 cursor-pointer px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600 hover:border-indigo-300 dark:hover:border-indigo-600 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/30 transition-all has-[:checked]:border-indigo-400 dark:has-[:checked]:border-indigo-500 has-[:checked]:bg-indigo-50 dark:has-[:checked]:bg-indigo-900/40">
                             <input
                                 type="radio"
                                 name="community-type"
                                 value="closed"
                                 className="accent-indigo-600 w-3.5 h-3.5"
                             />
-                            <Lock className="w-4 h-4 text-amber-500" />
+                            <Lock className="w-4 h-4 text-amber-500 dark:text-amber-400" />
                             <div className="flex flex-col">
-                                <span className="text-sm font-medium text-slate-700">Closed</span>
-                                <span className="text-[10px] text-slate-400">Members only</span>
+                                <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Closed</span>
+                                <span className="text-[10px] text-slate-400 dark:text-slate-500">Members only</span>
                             </div>
                         </label>
                     </div>
@@ -1670,7 +1670,7 @@ export const IntegratedView = ({
                             alert("Please fill in all fields");
                         }
                     }}
-                    className="w-full bg-indigo-600 text-white hover:bg-indigo-700 rounded-lg py-2 text-sm font-medium shadow-sm shadow-indigo-200 transition-all mt-1"
+                    className="w-full bg-indigo-600 text-white hover:bg-indigo-700 rounded-lg py-2 text-sm font-medium shadow-sm shadow-indigo-200 dark:shadow-indigo-900/50 transition-all mt-1"
                     disabled={creatingCommunity}
                 >
                     {creatingCommunity ? (
@@ -1685,9 +1685,9 @@ export const IntegratedView = ({
     const renderCommunitiesList = () => (
         <div className="space-y-6">
             {localCommunities.length === 0 ? (
-                <div className="text-center py-16 bg-slate-50 rounded-2xl">
-                    <p className="text-slate-500 font-medium">No communities yet</p>
-                    <p className="text-slate-400 text-sm mt-1">Create the first one!</p>
+                <div className="text-center py-16 bg-slate-50 dark:bg-slate-800 rounded-2xl">
+                    <p className="text-slate-500 dark:text-slate-400 font-medium">No communities yet</p>
+                    <p className="text-slate-400 dark:text-slate-500 text-sm mt-1">Create the first one!</p>
                 </div>
             ) : (
                 [...localCommunities]
@@ -1700,9 +1700,9 @@ export const IntegratedView = ({
                     }).map((community) => (
                         <div
                             key={community.id}
-                            className={`relative rounded-3xl overflow-hidden cursor-pointer transition-all hover:shadow-xl bg-white border ${selectedCommunityId === community.id
-                                ? "ring-2 ring-indigo-400 border-indigo-200"
-                                : "border-slate-200 hover:border-slate-300"
+                            className={`relative rounded-3xl overflow-hidden cursor-pointer transition-all hover:shadow-xl bg-white dark:bg-slate-800 border ${selectedCommunityId === community.id
+                                ? "ring-2 ring-indigo-400 dark:ring-indigo-500 border-indigo-200 dark:border-indigo-700"
+                                : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
                                 }`}
                             onClick={() => handleCommunityClick(community)}
                         >
@@ -1904,16 +1904,16 @@ export const IntegratedView = ({
     const renderPostsList = () => (
         <div className="space-y-6">
             {/* Topics filter strip */}
-            <div className="p-5 bg-white rounded-2xl border border-slate-100 shadow-sm">
+            <div className="p-5 bg-white dark:bg-slate-800 rounded-2xl border border-slate-100 dark:border-slate-700 shadow-sm">
                 <div className="flex flex-wrap items-center gap-2 mb-4">
-                    <span className="text-slate-500 text-sm mr-2">Filter:</span>
+                    <span className="text-slate-500 dark:text-slate-400 text-sm mr-2">Filter:</span>
 
                     {/* Show all option */}
                     <button
                         onClick={() => setSelectedTopic(null)}
                         className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${selectedTopic === null
                             ? "bg-indigo-600 text-white"
-                            : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                            : "bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600"
                             }`}
                     >
                         All
@@ -1926,7 +1926,7 @@ export const IntegratedView = ({
                             onClick={() => setSelectedTopic(topic)}
                             className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${selectedTopic === topic
                                 ? "bg-indigo-600 text-white"
-                                : "bg-slate-100 text-slate-500 hover:bg-slate-200"
+                                : "bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600"
                                 }`}
                         >
                             {topic}
@@ -1946,11 +1946,11 @@ export const IntegratedView = ({
                 </div>
 
                 {/* Community info */}
-                <div className="flex items-center justify-between pt-3 border-t border-slate-100">
-                    <span className="text-slate-500 text-sm">
+                <div className="flex items-center justify-between pt-3 border-t border-slate-100 dark:border-slate-700">
+                    <span className="text-slate-500 dark:text-slate-400 text-sm">
                         {selectedCommunityId ? (
                             <>
-                                Viewing: <span className="text-slate-900 font-medium">{getCommunityName(selectedCommunityId)}</span>
+                                Viewing: <span className="text-slate-900 dark:text-slate-100 font-medium">{getCommunityName(selectedCommunityId)}</span>
                             </>
                         ) : (
                             "All communities"
@@ -1966,7 +1966,7 @@ export const IntegratedView = ({
                         return community?.coverImage ? (
                             <div className="relative mb-12">
                                 {/* Cover image container */}
-                                <div className="w-full h-44 rounded-2xl overflow-hidden border border-slate-200 shadow-sm">
+                                <div className="w-full h-44 rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-700 shadow-sm">
                                     <img 
                                         src={`https://gateway.pinata.cloud/ipfs/${community.coverImage}`} 
                                         alt={`${getCommunityName(selectedCommunityId)} cover`}
@@ -1981,7 +1981,7 @@ export const IntegratedView = ({
                                 {/* Community photo overlapping cover image */}
                                 <div className="absolute -bottom-10 left-6 flex items-end gap-4">
                                     {community.photo && (
-                                        <div className="w-28 h-28 rounded-2xl border-4 border-white overflow-hidden bg-white shadow-xl">
+                                        <div className="w-28 h-28 rounded-2xl border-4 border-white dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-800 shadow-xl">
                                             <img 
                                                 src={`https://gateway.pinata.cloud/ipfs/${community.photo}`} 
                                                 alt={community.name}
@@ -1995,15 +1995,15 @@ export const IntegratedView = ({
                                     )}
                                     {/* Community name next to photo */}
                                     <div className="mb-2">
-                                        <h2 className="text-2xl font-semibold text-slate-900">{community.name}</h2>
+                                        <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">{community.name}</h2>
                                     </div>
                                 </div>
                             </div>
                         ) : (
                             // Fallback when no cover image
-                            <div className="w-full p-4 rounded-2xl border border-slate-200 bg-white/90 backdrop-blur-sm mb-4 flex items-center shadow-sm">
+                            <div className="w-full p-4 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm mb-4 flex items-center shadow-sm">
                                 {community?.photo ? (
-                                    <div className="w-16 h-16 rounded-full border-2 border-slate-200 overflow-hidden mr-4">
+                                    <div className="w-16 h-16 rounded-full border-2 border-slate-200 dark:border-slate-700 overflow-hidden mr-4">
                                         <img 
                                             src={`https://gateway.pinata.cloud/ipfs/${community.photo}`} 
                                             alt={community.name}
@@ -2015,11 +2015,11 @@ export const IntegratedView = ({
                                         />
                                     </div>
                                 ) : (
-                                    <div className="w-16 h-16 rounded-full flex items-center justify-center bg-slate-100 text-slate-600 font-semibold border-2 border-slate-200 mr-4">
+                                    <div className="w-16 h-16 rounded-full flex items-center justify-center bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-semibold border-2 border-slate-200 dark:border-slate-600 mr-4">
                                         {community?.name.charAt(0).toUpperCase() || "C"}
                                     </div>
                                 )}
-                                <h2 className="text-xl font-semibold text-slate-900">{community?.name}</h2>
+                                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{community?.name}</h2>
                             </div>
                         );
                     })()}
@@ -2031,10 +2031,10 @@ export const IntegratedView = ({
                 const isMember = community?.isMember || community?.isCreator;
                 if (!isCommunityOpen(selectedCommunityId) && !isMember) {
                     return (
-                        <div className="p-8 text-center bg-white/90 backdrop-blur-sm rounded-2xl border border-amber-200 shadow-sm">
+                        <div className="p-8 text-center bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-amber-200 dark:border-amber-800 shadow-sm">
                             <Lock className="w-12 h-12 text-amber-400 mx-auto mb-4" />
-                            <p className="text-slate-700 mb-2 font-medium">This is a closed community</p>
-                            <p className="text-slate-500 text-sm mb-4">
+                            <p className="text-slate-700 dark:text-slate-300 mb-2 font-medium">This is a closed community</p>
+                            <p className="text-slate-500 dark:text-slate-400 text-sm mb-4">
                                 Request access to view posts and participate in discussions.
                             </p>
                             {currentUserAddress && !hasPendingRequest(selectedCommunityId, currentUserAddress) ? (
@@ -2090,9 +2090,9 @@ export const IntegratedView = ({
                 }
                 return true;
             })() ? (
-                <div className="p-8 text-center bg-white/90 backdrop-blur-sm rounded-2xl border border-slate-200 shadow-sm">
-                    <p className="text-slate-700 mb-2 font-medium">No posts found with the current filters.</p>
-                    <p className="text-slate-500 text-sm">
+                <div className="p-8 text-center bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm rounded-2xl border border-slate-200 dark:border-slate-700 shadow-sm">
+                    <p className="text-slate-700 dark:text-slate-300 mb-2 font-medium">No posts found with the current filters.</p>
+                    <p className="text-slate-500 dark:text-slate-400 text-sm">
                         {selectedTopic
                             ? `There are no posts with the topic "${selectedTopic}".`
                             : selectedCommunityId
@@ -2104,7 +2104,7 @@ export const IntegratedView = ({
                 filteredPosts.map((post) => (
                     <div
                         key={post.id}
-                        className="bg-white rounded-2xl border border-slate-100 p-6 shadow-sm hover:shadow-md transition-all"
+                        className="bg-white dark:bg-slate-800 rounded-2xl border border-slate-100 dark:border-slate-700 p-6 shadow-sm hover:shadow-md transition-all"
                     >
                         <div className="flex justify-between items-start mb-3">
                             <div>
@@ -2117,14 +2117,14 @@ export const IntegratedView = ({
                                         className="mr-3"
                                     />
                                     <div className="flex flex-col">
-                                        <div className="flex items-center gap-2 text-xs text-slate-400">
+                                        <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
                                             <span>{formatDate(post.timestamp)}</span>
                                             <span>•</span>
-                                            <span className="bg-slate-100 text-slate-500 px-2 py-0.5 rounded-md">
+                                            <span className="bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 px-2 py-0.5 rounded-md">
                                                 {post.topic}
                                             </span>
                                             <span>•</span>
-                                            <span className="text-slate-500">{getCommunityName(post.communityId)}</span>
+                                            <span className="text-slate-500 dark:text-slate-400">{getCommunityName(post.communityId)}</span>
                                         </div>
                                     </div>
                                 </div>
@@ -2139,18 +2139,18 @@ export const IntegratedView = ({
                                             e.stopPropagation();
                                             togglePostMenu(post.id);
                                         }}
-                                        className="p-2 rounded-lg hover:bg-slate-100 transition-colors text-slate-400 hover:text-slate-600"
+                                        className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300"
                                         title="Post options"
                                     >
                                         <MoreVertical className="w-4 h-4" />
                                     </button>
                                     
                                     {showPostMenu[post.id] && (
-                                        <div className="absolute right-0 top-full mt-1 bg-white rounded-xl shadow-lg border border-slate-200 py-1 z-10 min-w-[140px]">
+                                        <div className="absolute right-0 top-full mt-1 bg-white dark:bg-slate-800 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 py-1 z-10 min-w-[140px]">
                                             <button
                                                 onClick={() => handleDeletePost(post.id, post.author || '')}
                                                 disabled={deletingPost[post.id]}
-                                                className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2 transition-colors disabled:opacity-50"
+                                                className="w-full px-4 py-2 text-left text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2 transition-colors disabled:opacity-50"
                                             >
                                                 <Trash2 className="w-4 h-4" />
                                                 {deletingPost[post.id] ? 'Deleting...' : 'Delete Post'}
@@ -2171,12 +2171,12 @@ export const IntegratedView = ({
                                 <img
                                     src={post.imageUrl}
                                     alt="Post attachment"
-                                    className="max-w-full max-h-96 rounded-xl border border-slate-200 object-contain"
+                                    className="max-w-full max-h-96 rounded-xl border border-slate-200 dark:border-slate-700 object-contain"
                                 />
                             </div>
                         )}
 
-                        <div className="flex items-center mt-5 pt-4 border-t border-slate-100 gap-4 text-sm text-slate-400">
+                        <div className="flex items-center mt-5 pt-4 border-t border-slate-100 dark:border-slate-700 gap-4 text-sm text-slate-400 dark:text-slate-500">
                             <button
                                 onClick={() => handleLikePost(post.id)}
                                 className={`flex items-center gap-1.5 transition-colors ${
@@ -2203,8 +2203,8 @@ export const IntegratedView = ({
 
                         {/* Comments section */}
                         {expandedComments[post.id] && (
-                            <div className="mt-5 pt-4 border-t border-slate-100">
-                                <h3 className="text-slate-600 mb-4 font-medium text-sm">Comments</h3>
+                            <div className="mt-5 pt-4 border-t border-slate-100 dark:border-slate-700">
+                                <h3 className="text-slate-600 dark:text-slate-300 mb-4 font-medium text-sm">Comments</h3>
 
                                 {/* Comment input */}
                                 <div className="flex mb-5 gap-3">
@@ -2216,7 +2216,7 @@ export const IntegratedView = ({
                                             [post.id]: e.target.value
                                         })}
                                         placeholder="Write a comment..."
-                                        className="flex-grow bg-slate-50 border border-slate-200 rounded-xl px-4 py-2.5 text-slate-900 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:border-indigo-400"
+                                        className="flex-grow bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-xl px-4 py-2.5 text-slate-900 dark:text-slate-100 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:focus:ring-indigo-800 focus:border-indigo-400 dark:focus:border-indigo-600 placeholder:text-slate-400 dark:placeholder:text-slate-500"
                                         onKeyPress={(e) => {
                                             if (e.key === 'Enter') {
                                                 addComment(post.id);
@@ -2236,7 +2236,7 @@ export const IntegratedView = ({
                                 {/* Comments list */}
                                 <div className="space-y-3 mb-4">
                                     {loadingComments[post.id] ? (
-                                        <div className="text-center text-slate-500">
+                                        <div className="text-center text-slate-500 dark:text-slate-400">
                                             Loading comments...
                                         </div>
                                     ) : comments[post.id]?.length > 0 ? (
@@ -2244,7 +2244,7 @@ export const IntegratedView = ({
                                             .filter(comment => !isUserHidden(comment.author))
                                             .sort((a, b) => Number(a.timestamp) - Number(b.timestamp))
                                             .map((comment) => (
-                                            <div key={comment.id} className="border border-slate-100 rounded-xl p-4 bg-slate-50">
+                                            <div key={comment.id} className="border border-slate-100 dark:border-slate-700 rounded-xl p-4 bg-slate-50 dark:bg-slate-700/50">
                                                 <div className="flex items-start">
                                                     <div className="mr-3 flex-shrink-0">
                                                         <UserAvatar 
@@ -2255,7 +2255,7 @@ export const IntegratedView = ({
                                                     </div>
                                                     <div className="flex-1">
                                                         <div className="flex justify-between items-center">
-                                                            <span className="text-slate-400 text-xs">
+                                                            <span className="text-slate-400 dark:text-slate-500 text-xs">
                                                                 {formatDate(comment.timestamp)}
                                                             </span>
                                                             {/* Comment options menu - only for author */}
@@ -2267,18 +2267,18 @@ export const IntegratedView = ({
                                                                             e.stopPropagation();
                                                                             toggleCommentMenu(comment.id);
                                                                         }}
-                                                                        className="p-1 rounded-lg hover:bg-slate-200 transition-colors text-slate-400 hover:text-slate-600"
+                                                                        className="p-1 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300"
                                                                         title="Comment options"
                                                                     >
                                                                         <MoreVertical className="w-3.5 h-3.5" />
                                                                     </button>
                                                                     
                                                                     {showCommentMenu[comment.id] && (
-                                                                        <div className="absolute right-0 top-full mt-1 bg-white rounded-lg shadow-lg border border-slate-200 py-1 z-10 min-w-[120px]">
+                                                                        <div className="absolute right-0 top-full mt-1 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-slate-200 dark:border-slate-700 py-1 z-10 min-w-[120px]">
                                                                             <button
                                                                                 onClick={() => handleDeleteComment(comment)}
                                                                                 disabled={deletingComment[comment.id]}
-                                                                                className="w-full px-3 py-1.5 text-left text-xs text-red-600 hover:bg-red-50 flex items-center gap-2 disabled:opacity-50"
+                                                                                className="w-full px-3 py-1.5 text-left text-xs text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center gap-2 disabled:opacity-50"
                                                                             >
                                                                                 <Trash2 className="w-3 h-3" />
                                                                                 {deletingComment[comment.id] ? "Deleting..." : "Delete"}
@@ -2288,13 +2288,13 @@ export const IntegratedView = ({
                                                                 </div>
                                                             )}
                                                         </div>
-                                                        <p className="text-slate-700 text-sm mt-1">{comment.content}</p>
+                                                        <p className="text-slate-700 dark:text-slate-300 text-sm mt-1">{comment.content}</p>
                                                     </div>
                                                 </div>
                                             </div>
                                         ))
                                     ) : (
-                                        <p className="text-slate-500 text-sm italic">No comments yet. Be the first to comment!</p>
+                                        <p className="text-slate-500 dark:text-slate-400 text-sm italic">No comments yet. Be the first to comment!</p>
                                     )}
                                 </div>
                             </div>

--- a/components/MembershipRequestsPanel.tsx
+++ b/components/MembershipRequestsPanel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import { useCommunitySettings } from "@/contexts/CommunitySettingsContext";
+import { UserPlus, Check, X } from "lucide-react";
+
+interface MembershipRequestsPanelProps {
+    communityId: string;
+    isCreator: boolean;
+    onApprove: (requesterAddress: string) => Promise<void>;
+    currentUserAddress?: string;
+}
+
+export const MembershipRequestsPanel: React.FC<MembershipRequestsPanelProps> = ({
+    communityId,
+    isCreator,
+    onApprove,
+    currentUserAddress
+}) => {
+    const { getPendingRequests, approveMembership, rejectMembership } = useCommunitySettings();
+    const requests = getPendingRequests(communityId);
+
+    // Solo mostrar si es creador y hay solicitudes pendientes
+    if (!isCreator || requests.length === 0) return null;
+
+    const handleApprove = async (requestId: string) => {
+        const requesterAddress = approveMembership(requestId, currentUserAddress || '');
+        if (requesterAddress) {
+            // Llamar a la función del contrato para unir al usuario
+            await onApprove(requesterAddress);
+        }
+    };
+
+    const handleReject = (requestId: string) => {
+        rejectMembership(requestId, currentUserAddress || '');
+    };
+
+    return (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4">
+            <h3 className="font-medium text-amber-800 mb-3 flex items-center gap-2">
+                <UserPlus className="w-4 h-4" />
+                Pending Membership Requests ({requests.length})
+            </h3>
+            <div className="space-y-2">
+                {requests.map(request => (
+                    <div
+                        key={request.id}
+                        className="flex items-center justify-between bg-white p-3 rounded-lg border border-amber-100"
+                    >
+                        <div className="flex flex-col">
+                            <span className="text-sm font-medium text-slate-700">
+                                {request.requesterAddress.slice(0, 6)}...{request.requesterAddress.slice(-4)}
+                            </span>
+                            <span className="text-xs text-slate-400">
+                                {new Date(request.requestedAt).toLocaleDateString()}
+                            </span>
+                        </div>
+                        <div className="flex gap-2">
+                            <button
+                                onClick={() => handleApprove(request.id)}
+                                className="flex items-center gap-1 text-xs bg-green-500 text-white px-3 py-1.5 rounded-lg hover:bg-green-600 transition-colors"
+                            >
+                                <Check className="w-3 h-3" />
+                                Approve
+                            </button>
+                            <button
+                                onClick={() => handleReject(request.id)}
+                                className="flex items-center gap-1 text-xs bg-red-500 text-white px-3 py-1.5 rounded-lg hover:bg-red-600 transition-colors"
+                            >
+                                <X className="w-3 h-3" />
+                                Reject
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -16,7 +16,11 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <Button variant="outline" size="icon" className="relative">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="relative bg-transparent border-0 shadow-none hover:bg-transparent focus-visible:ring-0"
+      >
         <Sun className="h-[1.2rem] w-[1.2rem]" />
         <span className="sr-only">Toggle theme</span>
       </Button>
@@ -27,10 +31,10 @@ export function ThemeToggle() {
 
   return (
     <Button
-      variant="outline"
+      variant="ghost"
       size="icon"
       onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="relative overflow-hidden transition-all duration-300 hover:scale-105"
+      className="relative overflow-hidden transition-all duration-300 hover:scale-105 bg-transparent border-0 shadow-none hover:bg-transparent focus-visible:ring-0"
     >
       <div className="relative w-full h-full flex items-center justify-center">
         <Sun 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -5,36 +5,46 @@ import { Moon, Sun } from "lucide-react"
 import { useTheme } from "next-themes"
 
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 
 export function ThemeToggle() {
-  const { setTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = React.useState(false)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <Button variant="outline" size="icon" className="relative">
+        <Sun className="h-[1.2rem] w-[1.2rem]" />
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    )
+  }
+
+  const isDark = theme === "dark"
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
-          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-          <span className="sr-only">Toggle theme</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="relative overflow-hidden transition-all duration-300 hover:scale-105"
+    >
+      <div className="relative w-full h-full flex items-center justify-center">
+        <Sun 
+          className={`h-[1.2rem] w-[1.2rem] transition-all duration-300 ${
+            isDark ? "opacity-0 scale-0 rotate-90" : "opacity-100 scale-100 rotate-0"
+          }`} 
+        />
+        <Moon 
+          className={`absolute h-[1.2rem] w-[1.2rem] transition-all duration-300 ${
+            isDark ? "opacity-100 scale-100 rotate-0" : "opacity-0 scale-0 -rotate-90"
+          }`} 
+        />
+      </div>
+      <span className="sr-only">Toggle theme</span>
+    </Button>
   )
 }

--- a/contexts/CommunitySettingsContext.tsx
+++ b/contexts/CommunitySettingsContext.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
+
+// Tipos para configuración de comunidades
+interface CommunitySettings {
+  communityId: string;
+  isClosed: boolean;
+  creatorAddress: string;
+  createdAt: number;
+}
+
+interface MembershipRequest {
+  id: string; // `${communityId}_${requesterAddress}`
+  communityId: string;
+  requesterAddress: string;
+  requestedAt: number;
+  status: 'pending' | 'approved' | 'rejected';
+  reviewedBy?: string;
+  reviewedAt?: number;
+}
+
+interface CommunitySettingsContextProps {
+  communitySettings: CommunitySettings[];
+  membershipRequests: MembershipRequest[];
+  setCommunityType: (communityId: string, isClosed: boolean, creatorAddress: string) => void;
+  isCommunityOpen: (communityId: string) => boolean;
+  getCommunitySettings: (communityId: string) => CommunitySettings | undefined;
+  canViewContent: (communityId: string, userAddress: string, isMember: boolean) => boolean;
+  requestMembership: (communityId: string, requesterAddress: string) => void;
+  approveMembership: (requestId: string, reviewerAddress: string) => string | null; // returns requester address
+  rejectMembership: (requestId: string, reviewerAddress: string) => void;
+  getPendingRequests: (communityId: string) => MembershipRequest[];
+  getUserRequests: (userAddress: string) => MembershipRequest[];
+  hasPendingRequest: (communityId: string, userAddress: string) => boolean;
+  getRequestStatus: (communityId: string, userAddress: string) => 'pending' | 'approved' | 'rejected' | null;
+}
+
+const CommunitySettingsContext = createContext<CommunitySettingsContextProps>({
+  communitySettings: [],
+  membershipRequests: [],
+  setCommunityType: () => {},
+  isCommunityOpen: () => true,
+  getCommunitySettings: () => undefined,
+  canViewContent: () => true,
+  requestMembership: () => {},
+  approveMembership: () => null,
+  rejectMembership: () => {},
+  getPendingRequests: () => [],
+  getUserRequests: () => [],
+  hasPendingRequest: () => false,
+  getRequestStatus: () => null,
+});
+
+// localStorage keys
+const COMMUNITY_SETTINGS_KEY = "nodespeak_community_settings";
+const MEMBERSHIP_REQUESTS_KEY = "nodespeak_membership_requests";
+
+export const CommunitySettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [communitySettings, setCommunitySettings] = useState<CommunitySettings[]>([]);
+  const [membershipRequests, setMembershipRequests] = useState<MembershipRequest[]>([]);
+
+  // Cargar datos desde localStorage al montar
+  useEffect(() => {
+    const storedSettings = localStorage.getItem(COMMUNITY_SETTINGS_KEY);
+    if (storedSettings) {
+      try {
+        setCommunitySettings(JSON.parse(storedSettings));
+      } catch (e) {
+        console.error("Error parsing community settings from localStorage:", e);
+      }
+    }
+
+    const storedRequests = localStorage.getItem(MEMBERSHIP_REQUESTS_KEY);
+    if (storedRequests) {
+      try {
+        setMembershipRequests(JSON.parse(storedRequests));
+      } catch (e) {
+        console.error("Error parsing membership requests from localStorage:", e);
+      }
+    }
+  }, []);
+
+  // Guardar settings en localStorage cuando cambien
+  useEffect(() => {
+    if (communitySettings.length > 0) {
+      localStorage.setItem(COMMUNITY_SETTINGS_KEY, JSON.stringify(communitySettings));
+    }
+  }, [communitySettings]);
+
+  // Guardar requests en localStorage cuando cambien
+  useEffect(() => {
+    if (membershipRequests.length > 0) {
+      localStorage.setItem(MEMBERSHIP_REQUESTS_KEY, JSON.stringify(membershipRequests));
+    }
+  }, [membershipRequests]);
+
+  // Establecer tipo de comunidad (al crear)
+  const setCommunityType = useCallback((communityId: string, isClosed: boolean, creatorAddress: string) => {
+    setCommunitySettings(prev => {
+      // Si ya existe, actualizar
+      const existing = prev.find(s => s.communityId === communityId);
+      if (existing) {
+        return prev.map(s =>
+          s.communityId === communityId
+            ? { ...s, isClosed, creatorAddress }
+            : s
+        );
+      }
+      // Si no existe, agregar
+      return [...prev, {
+        communityId,
+        isClosed,
+        creatorAddress,
+        createdAt: Date.now()
+      }];
+    });
+  }, []);
+
+  // Verificar si comunidad es abierta (default: true)
+  const isCommunityOpen = useCallback((communityId: string): boolean => {
+    const settings = communitySettings.find(s => s.communityId === communityId);
+    // Si no hay configuración, es abierta por defecto
+    if (!settings) return true;
+    return !settings.isClosed;
+  }, [communitySettings]);
+
+  // Obtener configuración de comunidad
+  const getCommunitySettings = useCallback((communityId: string): CommunitySettings | undefined => {
+    return communitySettings.find(s => s.communityId === communityId);
+  }, [communitySettings]);
+
+  // Determinar si usuario puede ver contenido
+  const canViewContent = useCallback((communityId: string, userAddress: string, isMember: boolean): boolean => {
+    // Si es miembro, siempre puede ver
+    if (isMember) return true;
+
+    // Buscar configuración
+    const settings = communitySettings.find(s => s.communityId === communityId);
+
+    // Si no hay config o es abierta, puede ver
+    if (!settings || !settings.isClosed) return true;
+
+    // Comunidad cerrada y no es miembro: no puede ver
+    return false;
+  }, [communitySettings]);
+
+  // Solicitar membresía
+  const requestMembership = useCallback((communityId: string, requesterAddress: string) => {
+    if (!requesterAddress) return;
+
+    const requestId = `${communityId}_${requesterAddress.toLowerCase()}`;
+
+    setMembershipRequests(prev => {
+      // Si ya existe una solicitud, no crear otra
+      const existing = prev.find(r => r.id === requestId);
+      if (existing) return prev;
+
+      return [...prev, {
+        id: requestId,
+        communityId,
+        requesterAddress: requesterAddress.toLowerCase(),
+        requestedAt: Date.now(),
+        status: 'pending'
+      }];
+    });
+  }, []);
+
+  // Aprobar solicitud de membresía
+  const approveMembership = useCallback((requestId: string, reviewerAddress: string): string | null => {
+    let requesterAddress: string | null = null;
+
+    setMembershipRequests(prev => {
+      return prev.map(r => {
+        if (r.id === requestId && r.status === 'pending') {
+          requesterAddress = r.requesterAddress;
+          return {
+            ...r,
+            status: 'approved' as const,
+            reviewedBy: reviewerAddress.toLowerCase(),
+            reviewedAt: Date.now()
+          };
+        }
+        return r;
+      });
+    });
+
+    return requesterAddress;
+  }, []);
+
+  // Rechazar solicitud de membresía
+  const rejectMembership = useCallback((requestId: string, reviewerAddress: string) => {
+    setMembershipRequests(prev => {
+      return prev.map(r => {
+        if (r.id === requestId && r.status === 'pending') {
+          return {
+            ...r,
+            status: 'rejected' as const,
+            reviewedBy: reviewerAddress.toLowerCase(),
+            reviewedAt: Date.now()
+          };
+        }
+        return r;
+      });
+    });
+  }, []);
+
+  // Obtener solicitudes pendientes para una comunidad
+  const getPendingRequests = useCallback((communityId: string): MembershipRequest[] => {
+    return membershipRequests.filter(
+      r => r.communityId === communityId && r.status === 'pending'
+    );
+  }, [membershipRequests]);
+
+  // Obtener solicitudes de un usuario
+  const getUserRequests = useCallback((userAddress: string): MembershipRequest[] => {
+    if (!userAddress) return [];
+    return membershipRequests.filter(
+      r => r.requesterAddress === userAddress.toLowerCase()
+    );
+  }, [membershipRequests]);
+
+  // Verificar si hay solicitud pendiente
+  const hasPendingRequest = useCallback((communityId: string, userAddress: string): boolean => {
+    if (!userAddress) return false;
+    return membershipRequests.some(
+      r => r.communityId === communityId &&
+           r.requesterAddress === userAddress.toLowerCase() &&
+           r.status === 'pending'
+    );
+  }, [membershipRequests]);
+
+  // Obtener estado de solicitud
+  const getRequestStatus = useCallback((communityId: string, userAddress: string): 'pending' | 'approved' | 'rejected' | null => {
+    if (!userAddress) return null;
+    const request = membershipRequests.find(
+      r => r.communityId === communityId && r.requesterAddress === userAddress.toLowerCase()
+    );
+    return request?.status || null;
+  }, [membershipRequests]);
+
+  return (
+    <CommunitySettingsContext.Provider
+      value={{
+        communitySettings,
+        membershipRequests,
+        setCommunityType,
+        isCommunityOpen,
+        getCommunitySettings,
+        canViewContent,
+        requestMembership,
+        approveMembership,
+        rejectMembership,
+        getPendingRequests,
+        getUserRequests,
+        hasPendingRequest,
+        getRequestStatus,
+      }}
+    >
+      {children}
+    </CommunitySettingsContext.Provider>
+  );
+};
+
+export const useCommunitySettings = () => useContext(CommunitySettingsContext);


### PR DESCRIPTION
Convierte header de comunidad en link clickeable hacia la página del foro con communityId y remueve el link Communities del header principal.

Modo oscuro completo en la página de perfil, incluyendo backgrounds, borders, textos y componentes interactivos.

Actualiza estilos de ThemeToggle → cambia variant="outline" → variant="ghost" y hace el botón totalmente transparente, sin bordes ni sombras.

Simplificación de ThemeToggle → elimina dropdown, usa botón toggle directo Light/Dark + animaciones suaves para íconos.

Modo oscuro completo en toda la aplicación usando ThemeToggle y estilos dark: en todas las páginas.

Reversión temporal: header de comunidad vuelve a ser div estático + restaura link Communities en el header principal.

Convierte nuevamente el header de comunidad en link clickeable con parámetro communityId para navegación desde Activity.

Elimina link Communities del header en página de actividad para simplificar navegación.

Implementa sistema de comunidades cerradas con solicitudes de membresía y control de acceso via CommunitySettingsContext.